### PR TITLE
notify admins of new sign up

### DIFF
--- a/src/DevBetterWeb.Core/Events/NewMemberCreatedAndProfileUpdatedEvent.cs
+++ b/src/DevBetterWeb.Core/Events/NewMemberCreatedAndProfileUpdatedEvent.cs
@@ -3,9 +3,9 @@ using DevBetterWeb.Core.SharedKernel;
 
 namespace DevBetterWeb.Core.Events
 {
-  public class NewMemberCreatedEvent : BaseDomainEvent
+  public class NewMemberCreatedAndProfileUpdatedEvent : BaseDomainEvent
   {
-    public NewMemberCreatedEvent(Member member)
+    public NewMemberCreatedAndProfileUpdatedEvent(Member member)
     {
       Member = member;
     }

--- a/src/DevBetterWeb.Infrastructure/Handlers/NotifyOnNewMemberCreatedAndProfileUpdatedHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/NotifyOnNewMemberCreatedAndProfileUpdatedHandler.cs
@@ -1,0 +1,45 @@
+﻿using DevBetterWeb.Core;
+using DevBetterWeb.Core.Events;
+using DevBetterWeb.Core.Interfaces;
+using DevBetterWeb.Web.Areas.Identity.Data;
+using Microsoft.AspNetCore.Identity;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace DevBetterWeb.Infrastructure.Handlers
+{
+  public class NotifyOnNewMemberCreatedAndProfileUpdatedHandler : IHandle<NewMemberCreatedAndProfileUpdatedEvent>
+  {
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IEmailService _emailService;
+
+    public NotifyOnNewMemberCreatedAndProfileUpdatedHandler(UserManager<ApplicationUser> userManager,
+        IEmailService emailService)
+    {
+      _userManager = userManager;
+      _emailService = emailService;
+    }
+
+    public async Task Handle(NewMemberCreatedAndProfileUpdatedEvent domainEvent)
+    {
+      var usersInAdminRole = await _userManager.GetUsersInRoleAsync(AuthConstants.Roles.ADMINISTRATORS);
+
+      var newMemberUser = await _userManager.FindByIdAsync(domainEvent.Member.UserId);
+      string newMemberEmail = await _userManager.GetEmailAsync(newMemberUser);
+
+      foreach (var emailAddress in usersInAdminRole.Select(user => user.Email))
+      {
+        string subject = $"[devBetter] New Member {domainEvent.Member.UserFullName()}";
+        string message = $"A new Member with id {domainEvent.Member.UserId} has signed up and updated their membership profile.\n" +
+          $"Member email: {newMemberEmail} \n" +
+          $"Member subscription(s): ";
+        foreach(var subscription in domainEvent.Member.Subscriptions)
+        {
+          message = message + $"\n    {subscription.Dates.StartDate} to {subscription.Dates.EndDate}";
+        }
+        message = message + $"\nView {domainEvent.Member.FirstName}'s profile at: https://devbetter.com/User/Details/ {domainEvent.Member.UserId}";
+        await _emailService.SendEmailAsync(emailAddress, subject, message);
+      }
+    }
+  }
+}

--- a/src/DevBetterWeb.Infrastructure/Handlers/NotifyOnNewMemberCreatedHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/NotifyOnNewMemberCreatedHandler.cs
@@ -8,28 +8,28 @@ using System.Threading.Tasks;
 
 namespace DevBetterWeb.Infrastructure.Handlers
 {
-    public class NotifyOnNewMemberCreatedHandler : IHandle<NewMemberCreatedEvent>
+  public class NotifyOnNewMemberCreatedHandler : IHandle<NewMemberCreatedEvent>
+  {
+    private readonly UserManager<ApplicationUser> _userManager;
+    private readonly IEmailService _emailService;
+
+    public NotifyOnNewMemberCreatedHandler(UserManager<ApplicationUser> userManager,
+        IEmailService emailService)
     {
-        private readonly UserManager<ApplicationUser> _userManager;
-        private readonly IEmailService _emailService;
-
-        public NotifyOnNewMemberCreatedHandler(UserManager<ApplicationUser> userManager,
-            IEmailService emailService)
-        {
-            _userManager = userManager;
-            _emailService = emailService;
-        }
-
-        public async Task Handle(NewMemberCreatedEvent domainEvent)
-        {
-            var usersInAdminRole = await _userManager.GetUsersInRoleAsync(AuthConstants.Roles.ADMINISTRATORS);
-
-            foreach(var emailAddress in usersInAdminRole.Select(user => user.Email))
-            {
-                string subject = $"[devBetter] New Member {domainEvent.Member.UserFullName()}";
-                string message = $"A new Member with id {domainEvent.Member.UserId} has signed up and added their membership profile."; 
-                await _emailService.SendEmailAsync(emailAddress, subject, message);
-            }
-        }
+      _userManager = userManager;
+      _emailService = emailService;
     }
+
+    public async Task Handle(NewMemberCreatedEvent domainEvent)
+    {
+      var usersInAdminRole = await _userManager.GetUsersInRoleAsync(AuthConstants.Roles.ADMINISTRATORS);
+
+      foreach(var emailAddress in usersInAdminRole.Select(user => user.Email))
+      {
+        string subject = $"[devBetter] New Member {domainEvent.Member.UserFullName()}";
+        string message = $"A new Member with id {domainEvent.Member.UserId} has signed up and added their membership profile.";
+        await _emailService.SendEmailAsync(emailAddress, subject, message);
+      }
+    }
+  }
 }


### PR DESCRIPTION
event and handler to notify admins of new sign up have been created. These send an email to admins with relevant information and are designed to fire once the new member has made updates to their profile (that way the email can actually include the member's name), but they have not been wired up yet.

fixes #172 