### PR TITLE
Fix video search

### DIFF
--- a/src/DevBetterWeb.Core/Specs/ArchiveVideoByPageSpec.cs
+++ b/src/DevBetterWeb.Core/Specs/ArchiveVideoByPageSpec.cs
@@ -9,7 +9,6 @@ public class ArchiveVideoByPageSpec : Specification<ArchiveVideo>
     if (string.IsNullOrEmpty(search))
     {
       Query
-        .Where(s => s.ShowNotes != null && !string.IsNullOrEmpty(search) && s.ShowNotes.Contains(search))
         .OrderByDescending(x => x.DateCreated)
         .Skip(skip)
         .Take(size);
@@ -17,6 +16,7 @@ public class ArchiveVideoByPageSpec : Specification<ArchiveVideo>
     else
     {
       Query
+        .Where(s => s.ShowNotes != null && !string.IsNullOrEmpty(search) && s.ShowNotes.Contains(search))
         .OrderByDescending(x => x.DateCreated)
         .Skip(skip)
         .Take(size);

--- a/src/DevBetterWeb.Web/Controllers/VideosController.cs
+++ b/src/DevBetterWeb.Web/Controllers/VideosController.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading.Tasks;
 using AutoMapper;
 using DevBetterWeb.Core;
@@ -9,7 +8,6 @@ using DevBetterWeb.Core.Interfaces;
 using DevBetterWeb.Core.Specs;
 using DevBetterWeb.Vimeo.Services.VideoServices;
 using DevBetterWeb.Web.Models;
-using DevBetterWeb.Web.Models.Vimeo;
 using DevBetterWeb.Web.Pages.Admin.Videos;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;

--- a/src/DevBetterWeb.Web/Pages/Videos/Index.cshtml
+++ b/src/DevBetterWeb.Web/Pages/Videos/Index.cshtml
@@ -113,10 +113,11 @@
         currentPage = currentPageIndex;
         var userRole = '@(User.IsInRole("Administrators,Members,Alumni") ? "true" : "false")';
         if (userRole) {
+            const search = $("#SearchString").val();
             $.ajax({
                 type: "POST",
-                url: "/videos/list?search=" + $("#SearchString").val(),
-                data: { draw: '1', start: (currentPageIndex*recordsPage), length: recordsPage.toString() },
+                url: "/videos/list",
+                data: { draw: '1', start: (currentPageIndex*recordsPage), length: recordsPage.toString(), search: search },
                 dataType: "json",
                 success: function (videosReponse) {
                     var divHtml = "";

--- a/src/DevBetterWeb.Web/Pages/Videos/Index.cshtml.cs
+++ b/src/DevBetterWeb.Web/Pages/Videos/Index.cshtml.cs
@@ -1,11 +1,5 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
-using AutoMapper;
-using DevBetterWeb.Core;
-using DevBetterWeb.Vimeo.Services.VideoServices;
-using DevBetterWeb.Web.Models.Vimeo;
+﻿using DevBetterWeb.Core;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace DevBetterWeb.Web.Pages.Videos;

--- a/tests/DevBetterWeb.UnitTests/Core/Specs/ArchiveVideoByPageSpecEvaluate.cs
+++ b/tests/DevBetterWeb.UnitTests/Core/Specs/ArchiveVideoByPageSpecEvaluate.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using DevBetterWeb.Core.Entities;
+using DevBetterWeb.Core.Specs;
 using FluentAssertions;
 using Xunit;
 
@@ -15,14 +16,14 @@ public class ArchiveVideoByPageSpecEvaluate
   {
     _archiveVideos = new ArchiveVideo[]
     {
-      new ArchiveVideo()
+      new()
       {
         Id = 1,
         Title = "Video One",
         ShowNotes = "# Video about using markdown in ASP.NET Core",
         DateCreated = new DateTime(2019, 3, 8),
       },
-      new ArchiveVideo()
+      new()
       {
         Id = 2,
         Title = "Video Two",
@@ -31,14 +32,13 @@ public class ArchiveVideoByPageSpecEvaluate
     };
   }
 
-
   [Fact]
-  public void ReturnUnfilteredListGivenNullSearchExpression()
+  public void ReturnsUnfilteredListGivenNullSearchExpression()
   {
-    var sut = new DevBetterWeb.Core.Specs.ArchiveVideoByPageSpec(
+    var sut = new ArchiveVideoByPageSpec(
       skip: 0,
       size: 12,
-      search: null);
+      search: default);
 
     var result = sut.Evaluate(_archiveVideos);
 
@@ -48,9 +48,9 @@ public class ArchiveVideoByPageSpecEvaluate
   [Theory]
   [InlineData("markdown", 1)]
   [InlineData("some other value", 0)]
-  public void ReturnFilteredListGivenSearchExpression(string search, int expectedCount)
+  public void ReturnsFilteredListGivenSearchExpression(string search, int expectedCount)
   {
-    var sut = new DevBetterWeb.Core.Specs.ArchiveVideoByPageSpec(
+    var sut = new ArchiveVideoByPageSpec(
       skip: 0,
       size: 12,
       search: search);
@@ -60,14 +60,14 @@ public class ArchiveVideoByPageSpecEvaluate
     result.Should().HaveCount(expectedCount);
   }
 
-
   [Theory]
   [InlineData(0, 2)]
   [InlineData(1, 1)]
   [InlineData(2, 0)]
-  public void ReturnFilteredListGivenSkipExpression(int skip, int expectedCount)
+  [InlineData(3, 0)]
+  public void ReturnsFilteredListGivenSkipExpression(int skip, int expectedCount)
   {
-    var sut = new DevBetterWeb.Core.Specs.ArchiveVideoByPageSpec(
+    var sut = new ArchiveVideoByPageSpec(
       skip: skip,
       size: 12,
       search: default);
@@ -82,9 +82,9 @@ public class ArchiveVideoByPageSpecEvaluate
   [InlineData(1, 1)]
   [InlineData(2, 2)]
   [InlineData(3, 2)]
-  public void ReturnFilteredListGivenSizeExpression(int size, int expectedCount)
+  public void ReturnsFilteredListGivenSizeExpression(int size, int expectedCount)
   {
-    var sut = new DevBetterWeb.Core.Specs.ArchiveVideoByPageSpec(
+    var sut = new ArchiveVideoByPageSpec(
       skip: 0,
       size: size,
       search: default);

--- a/tests/DevBetterWeb.UnitTests/Core/Specs/ArchiveVideoByPageSpecEvaluate.cs
+++ b/tests/DevBetterWeb.UnitTests/Core/Specs/ArchiveVideoByPageSpecEvaluate.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using DevBetterWeb.Core.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace DevBetterWeb.UnitTests.Core.Specs;
+
+public class ArchiveVideoByPageSpecEvaluate
+{
+  private readonly IEnumerable<ArchiveVideo> _archiveVideos;
+
+  public ArchiveVideoByPageSpecEvaluate()
+  {
+    _archiveVideos = new ArchiveVideo[]
+    {
+      new ArchiveVideo()
+      {
+        Id = 1,
+        Title = "Video One",
+        ShowNotes = "# Video about using markdown in ASP.NET Core",
+        DateCreated = new DateTime(2019, 3, 8),
+      },
+      new ArchiveVideo()
+      {
+        Id = 2,
+        Title = "Video Two",
+        DateCreated = new DateTime(2019, 3, 15)
+      }
+    };
+  }
+
+
+  [Fact]
+  public void ReturnUnfilteredListGivenNullSearchExpression()
+  {
+    var sut = new DevBetterWeb.Core.Specs.ArchiveVideoByPageSpec(
+      skip: 0,
+      size: 12,
+      search: null);
+
+    var result = sut.Evaluate(_archiveVideos);
+
+    result.Should().HaveCount(_archiveVideos.Count());
+  }
+
+  [Theory]
+  [InlineData("markdown", 1)]
+  [InlineData("some other value", 0)]
+  public void ReturnFilteredListGivenSearchExpression(string search, int expectedCount)
+  {
+    var sut = new DevBetterWeb.Core.Specs.ArchiveVideoByPageSpec(
+      skip: 0,
+      size: 12,
+      search: search);
+
+    var result = sut.Evaluate(_archiveVideos);
+
+    result.Should().HaveCount(expectedCount);
+  }
+
+
+  [Theory]
+  [InlineData(0, 2)]
+  [InlineData(1, 1)]
+  [InlineData(2, 0)]
+  public void ReturnFilteredListGivenSkipExpression(int skip, int expectedCount)
+  {
+    var sut = new DevBetterWeb.Core.Specs.ArchiveVideoByPageSpec(
+      skip: skip,
+      size: 12,
+      search: default);
+
+    var result = sut.Evaluate(_archiveVideos);
+
+    result.Should().HaveCount(expectedCount);
+  }
+
+  [Theory]
+  [InlineData(0, 0)]
+  [InlineData(1, 1)]
+  [InlineData(2, 2)]
+  [InlineData(3, 2)]
+  public void ReturnFilteredListGivenSizeExpression(int size, int expectedCount)
+  {
+    var sut = new DevBetterWeb.Core.Specs.ArchiveVideoByPageSpec(
+      skip: 0,
+      size: size,
+      search: default);
+
+    var result = sut.Evaluate(_archiveVideos);
+
+    result.Should().HaveCount(expectedCount);
+  }
+}


### PR DESCRIPTION
This change fixes an issue in the video search functionality causing all videos to be filtered by default.

The original implementation along with this fix should fulfill issue #585.

I didn't see any examples of testing Specifications within this app so I introduced some tests for `ArchiveVideoByPageSpec`. Any feedback on those tests is very much appreciated!