### PR TITLE
Change video search field to Description

### DIFF
--- a/src/DevBetterWeb.Core/Specs/ArchiveVideoByPageSpec.cs
+++ b/src/DevBetterWeb.Core/Specs/ArchiveVideoByPageSpec.cs
@@ -16,7 +16,7 @@ public class ArchiveVideoByPageSpec : Specification<ArchiveVideo>
     else
     {
       Query
-        .Where(s => s.ShowNotes != null && !string.IsNullOrEmpty(search) && s.ShowNotes.Contains(search))
+        .Where(s => s.Description != null && !string.IsNullOrEmpty(search) && s.Description.Contains(search))
         .OrderByDescending(x => x.DateCreated)
         .Skip(skip)
         .Take(size);

--- a/src/DevBetterWeb.Core/Specs/ArchiveVideoFilteredSpec.cs
+++ b/src/DevBetterWeb.Core/Specs/ArchiveVideoFilteredSpec.cs
@@ -14,7 +14,7 @@ public class ArchiveVideoFilteredSpec : Specification<ArchiveVideo>
     else
     {
       Query
-        .Where(s => s.ShowNotes != null && !string.IsNullOrEmpty(search) && s.ShowNotes.Contains(search))
+        .Where(s => s.Description != null && !string.IsNullOrEmpty(search) && s.Description.Contains(search))
           .OrderByDescending(x => x.DateCreated);
     }
   }

--- a/src/DevBetterWeb.Web/SeedData.cs
+++ b/src/DevBetterWeb.Web/SeedData.cs
@@ -17,7 +17,7 @@ public static class SeedData
     var vid1 = new ArchiveVideo()
     {
       Title = "Video One",
-      ShowNotes = @"
+      Description = @"
 # Video about using markdown in ASP.NET Core
 
 In this video we talk about some stuff. In this video we talk about some stuff. In this video we talk about some stuff. In this video we talk about some stuff. In this video we talk about some stuff. In this video we talk about some stuff. 

--- a/tests/DevBetterWeb.UnitTests/Core/Specs/ArchiveVideoByPageSpecEvaluate.cs
+++ b/tests/DevBetterWeb.UnitTests/Core/Specs/ArchiveVideoByPageSpecEvaluate.cs
@@ -20,7 +20,7 @@ public class ArchiveVideoByPageSpecEvaluate
       {
         Id = 1,
         Title = "Video One",
-        ShowNotes = "# Video about using markdown in ASP.NET Core",
+        Description = "# Video about using markdown in ASP.NET Core",
         DateCreated = new DateTime(2019, 3, 8),
       },
       new()
@@ -47,7 +47,7 @@ public class ArchiveVideoByPageSpecEvaluate
 
   [Theory]
   [InlineData("markdown", 1)]
-  [InlineData("some other value", 0)]
+  [InlineData("some nonpresent value", 0)]
   public void ReturnsFilteredListGivenSearchExpression(string search, int expectedCount)
   {
     var sut = new ArchiveVideoByPageSpec(


### PR DESCRIPTION
Change video search to query off of `Description` instead of `ShowNotes` as no data in production uses that field