### PR TITLE
Packages updates and cleanup

### DIFF
--- a/src/DevBetterWeb.Web/DevBetterWeb.Web.csproj
+++ b/src/DevBetterWeb.Web/DevBetterWeb.Web.csproj
@@ -31,8 +31,6 @@
         <PackageReference Include="CSharpFunctionalExtensions" Version="2.27.0" />
         <PackageReference Include="Dapper" Version="2.0.123" />
         <PackageReference Include="GoogleReCaptcha.V3" Version="1.3.1" />
-        <PackageReference Include="MediatR" Version="9.0.0" />
-        <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.1" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
@@ -62,8 +60,8 @@
         <PackageReference Include="TagHelperSamples.Authorization" Version="3.0.56" />
         <PackageReference Include="Westwind.AspNetCore.Markdown" Version="3.7.0" />
         <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
-        <PackageReference Include="AutoMapper" Version="10.1.1" />
-        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+        <PackageReference Include="AutoMapper" Version="11.0.0" />
+        <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
 
     </ItemGroup>
 

--- a/src/DevBetterWeb.Web/Startup.cs
+++ b/src/DevBetterWeb.Web/Startup.cs
@@ -13,7 +13,6 @@ using DevBetterWeb.Infrastructure.Services;
 using DevBetterWeb.Web.Models;
 using GoogleReCaptcha.V3;
 using GoogleReCaptcha.V3.Interface;
-using MediatR;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
@@ -99,7 +98,6 @@ public class Startup
 
     var webProjectAssembly = typeof(Startup).Assembly;
     services.AddAutoMapper(webProjectAssembly);
-    services.AddMediatR(webProjectAssembly);
 
     services.AddScoped<IMapCoordinateService, GoogleMapCoordinateService>();
 


### PR DESCRIPTION
- update `AutoMapper` from 10.1.1 to 11.0.0
- update `AutoMapper.Extensions.Microsoft.DependencyInjection` from 8.1.1 to 11.0.0
- remove `Mediatr` and `MediatR.Extensions.Microsoft.DependencyInjection` packages, as well as MediatR services registration code 