### PR TITLE
Add subscription and billing activity related event notifications

### DIFF
--- a/src/DevBetterWeb.Core/Entities/Member.cs
+++ b/src/DevBetterWeb.Core/Entities/Member.cs
@@ -105,7 +105,7 @@ public class Member : BaseEntity, IAggregateRoot
       LastName = lastName;
       valueChanged = true;
     }
-    if (valueChanged)
+	if (valueChanged)
     {
       CreateOrUpdateUpdateEvent("Name");
     }
@@ -242,7 +242,7 @@ public class Member : BaseEntity, IAggregateRoot
 
     MemberSubscriptions.Add(subscription);
 
-	Events.Add(new SubscriptionAddedEvent(subscription));
+	Events.Add(new SubscriptionAddedEvent(this, subscription));
   }
 
   public void ExtendCurrentSubscription(DateTime newEndDate)
@@ -253,7 +253,7 @@ public class Member : BaseEntity, IAggregateRoot
       if (s.Dates.Contains(DateTime.Today))
       {
         s.Dates = new DateTimeRange(s.Dates.StartDate, newEndDate);
-		Events.Add(new SubscriptionUpdatedEvent(s));
+		Events.Add(new SubscriptionUpdatedEvent(this, s));
 		return;
       }
     }

--- a/src/DevBetterWeb.Core/Entities/Member.cs
+++ b/src/DevBetterWeb.Core/Entities/Member.cs
@@ -254,7 +254,6 @@ public class Member : BaseEntity, IAggregateRoot
       {
         s.Dates = new DateTimeRange(s.Dates.StartDate, newEndDate);
         Events.Add(new SubscriptionUpdatedEvent(this, s));
-        return;
       }
     }
   }

--- a/src/DevBetterWeb.Core/Entities/Member.cs
+++ b/src/DevBetterWeb.Core/Entities/Member.cs
@@ -242,7 +242,7 @@ public class Member : BaseEntity, IAggregateRoot
 
     MemberSubscriptions.Add(subscription);
 
-	Events.Add(new SubscriptionAddedEvent(this, subscription));
+    Events.Add(new SubscriptionAddedEvent(this, subscription));
   }
 
   public void ExtendCurrentSubscription(DateTime newEndDate)

--- a/src/DevBetterWeb.Core/Entities/Member.cs
+++ b/src/DevBetterWeb.Core/Entities/Member.cs
@@ -241,8 +241,6 @@ public class Member : BaseEntity, IAggregateRoot
     var subscription = new MemberSubscription(this.Id, subscriptionPlanId, subscriptionDateTimeRange);
 
     MemberSubscriptions.Add(subscription);
-
-    CreateOrUpdateUpdateEvent("Subscription Added");
   }
 
   public void ExtendCurrentSubscription(DateTime newEndDate)
@@ -253,7 +251,6 @@ public class Member : BaseEntity, IAggregateRoot
       if (s.Dates.Contains(DateTime.Today))
       {
         s.Dates = new DateTimeRange(s.Dates.StartDate, newEndDate);
-        CreateOrUpdateUpdateEvent("Subscription Updated");
       }
     }
   }
@@ -263,7 +260,6 @@ public class Member : BaseEntity, IAggregateRoot
     var details = new BillingDetails(UserFullName(), subscriptionPlanName, actionVerbPastTense, billingPeriod, DateTime.Now, amount);
     var activity = new BillingActivity(Id, details);
     BillingActivities.Add(activity);
-    CreateOrUpdateUpdateEvent("BillingActivities");
   }
 
   public void UpdateDiscord(string? discordUsername)

--- a/src/DevBetterWeb.Core/Entities/Member.cs
+++ b/src/DevBetterWeb.Core/Entities/Member.cs
@@ -263,9 +263,7 @@ public class Member : BaseEntity, IAggregateRoot
     var details = new BillingDetails(UserFullName(), subscriptionPlanName, actionVerbPastTense, billingPeriod, DateTime.Now, amount);
     var activity = new BillingActivity(Id, details);
     BillingActivities.Add(activity);
-		
-    var createEvent = new BillingActivityCreatedEvent(activity, this);
-    Events.Add(createEvent);
+    Events.Add(new BillingActivityCreatedEvent(activity, this));
   }
 
   public void UpdateDiscord(string? discordUsername)

--- a/src/DevBetterWeb.Core/Entities/Member.cs
+++ b/src/DevBetterWeb.Core/Entities/Member.cs
@@ -241,6 +241,8 @@ public class Member : BaseEntity, IAggregateRoot
     var subscription = new MemberSubscription(this.Id, subscriptionPlanId, subscriptionDateTimeRange);
 
     MemberSubscriptions.Add(subscription);
+
+	Events.Add(new SubscriptionAddedEvent(subscription));
   }
 
   public void ExtendCurrentSubscription(DateTime newEndDate)
@@ -251,6 +253,8 @@ public class Member : BaseEntity, IAggregateRoot
       if (s.Dates.Contains(DateTime.Today))
       {
         s.Dates = new DateTimeRange(s.Dates.StartDate, newEndDate);
+		Events.Add(new SubscriptionUpdatedEvent(s));
+		return;
       }
     }
   }
@@ -260,6 +264,9 @@ public class Member : BaseEntity, IAggregateRoot
     var details = new BillingDetails(UserFullName(), subscriptionPlanName, actionVerbPastTense, billingPeriod, DateTime.Now, amount);
     var activity = new BillingActivity(Id, details);
     BillingActivities.Add(activity);
+		
+	var createEvent = new BillingActivityCreatedEvent(activity, this);
+	Events.Add(createEvent);
   }
 
   public void UpdateDiscord(string? discordUsername)

--- a/src/DevBetterWeb.Core/Entities/Member.cs
+++ b/src/DevBetterWeb.Core/Entities/Member.cs
@@ -105,7 +105,7 @@ public class Member : BaseEntity, IAggregateRoot
       LastName = lastName;
       valueChanged = true;
     }
-	if (valueChanged)
+    if (valueChanged)
     {
       CreateOrUpdateUpdateEvent("Name");
     }
@@ -253,8 +253,8 @@ public class Member : BaseEntity, IAggregateRoot
       if (s.Dates.Contains(DateTime.Today))
       {
         s.Dates = new DateTimeRange(s.Dates.StartDate, newEndDate);
-		Events.Add(new SubscriptionUpdatedEvent(this, s));
-		return;
+        Events.Add(new SubscriptionUpdatedEvent(this, s));
+        return;
       }
     }
   }
@@ -265,8 +265,8 @@ public class Member : BaseEntity, IAggregateRoot
     var activity = new BillingActivity(Id, details);
     BillingActivities.Add(activity);
 		
-	var createEvent = new BillingActivityCreatedEvent(activity, this);
-	Events.Add(createEvent);
+    var createEvent = new BillingActivityCreatedEvent(activity, this);
+    Events.Add(createEvent);
   }
 
   public void UpdateDiscord(string? discordUsername)

--- a/src/DevBetterWeb.Core/Events/BillingActivityCreatedEvent.cs
+++ b/src/DevBetterWeb.Core/Events/BillingActivityCreatedEvent.cs
@@ -1,0 +1,16 @@
+﻿using DevBetterWeb.Core.Entities;
+using DevBetterWeb.Core.SharedKernel;
+
+namespace DevBetterWeb.Core.Events;
+
+public class BillingActivityCreatedEvent : BaseDomainEvent
+{
+  public BillingActivity BillingActivity { get; }
+  public Member Member { get; }
+	
+  public BillingActivityCreatedEvent(BillingActivity billingActivity, Member member)
+  {
+	BillingActivity = billingActivity;
+	Member = member;
+  }
+}

--- a/src/DevBetterWeb.Core/Events/BillingActivityCreatedEvent.cs
+++ b/src/DevBetterWeb.Core/Events/BillingActivityCreatedEvent.cs
@@ -8,10 +8,10 @@ public class BillingActivityCreatedEvent : BaseDomainEvent
 {
   public BillingActivity BillingActivity { get; }
   public Member Member { get; }
-	
+    
   public BillingActivityCreatedEvent(BillingActivity billingActivity, Member member)
   {
-	BillingActivity = Guard.Against.Null(billingActivity, nameof(billingActivity));
-	Member = Guard.Against.Null(member, nameof(member));
+    BillingActivity = Guard.Against.Null(billingActivity, nameof(billingActivity));
+    Member = Guard.Against.Null(member, nameof(member));
   }
 }

--- a/src/DevBetterWeb.Core/Events/BillingActivityCreatedEvent.cs
+++ b/src/DevBetterWeb.Core/Events/BillingActivityCreatedEvent.cs
@@ -1,4 +1,5 @@
-﻿using DevBetterWeb.Core.Entities;
+﻿using Ardalis.GuardClauses;
+using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Core.SharedKernel;
 
 namespace DevBetterWeb.Core.Events;
@@ -10,7 +11,7 @@ public class BillingActivityCreatedEvent : BaseDomainEvent
 	
   public BillingActivityCreatedEvent(BillingActivity billingActivity, Member member)
   {
-	BillingActivity = billingActivity;
-	Member = member;
+	BillingActivity = Guard.Against.Null(billingActivity, nameof(billingActivity));
+	Member = Guard.Against.Null(member, nameof(member));
   }
 }

--- a/src/DevBetterWeb.Core/Events/SubscriptionAddedEvent.cs
+++ b/src/DevBetterWeb.Core/Events/SubscriptionAddedEvent.cs
@@ -1,14 +1,17 @@
-﻿using DevBetterWeb.Core.Entities;
+﻿using Ardalis.GuardClauses;
+using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Core.SharedKernel;
 
 namespace DevBetterWeb.Core.Events;
 
 public class SubscriptionAddedEvent : BaseDomainEvent
 {
+  public Member Member { get; }
   public MemberSubscription MemberSubscription { get; }
   
-  public SubscriptionAddedEvent(MemberSubscription memberSubscription)
+  public SubscriptionAddedEvent(Member member, MemberSubscription memberSubscription)
   {
-  	MemberSubscription = memberSubscription;
+	Member = Guard.Against.Null(member, nameof(member));
+  	MemberSubscription = Guard.Against.Null(memberSubscription, nameof(memberSubscription));
   }
 }

--- a/src/DevBetterWeb.Core/Events/SubscriptionAddedEvent.cs
+++ b/src/DevBetterWeb.Core/Events/SubscriptionAddedEvent.cs
@@ -1,0 +1,14 @@
+﻿using DevBetterWeb.Core.Entities;
+using DevBetterWeb.Core.SharedKernel;
+
+namespace DevBetterWeb.Core.Events;
+
+public class SubscriptionAddedEvent : BaseDomainEvent
+{
+  public MemberSubscription MemberSubscription { get; }
+  
+  public SubscriptionAddedEvent(MemberSubscription memberSubscription)
+  {
+  	MemberSubscription = memberSubscription;
+  }
+}

--- a/src/DevBetterWeb.Core/Events/SubscriptionAddedEvent.cs
+++ b/src/DevBetterWeb.Core/Events/SubscriptionAddedEvent.cs
@@ -11,7 +11,7 @@ public class SubscriptionAddedEvent : BaseDomainEvent
   
   public SubscriptionAddedEvent(Member member, MemberSubscription memberSubscription)
   {
-	Member = Guard.Against.Null(member, nameof(member));
-  	MemberSubscription = Guard.Against.Null(memberSubscription, nameof(memberSubscription));
+    Member = Guard.Against.Null(member, nameof(member));
+    MemberSubscription = Guard.Against.Null(memberSubscription, nameof(memberSubscription));
   }
 }

--- a/src/DevBetterWeb.Core/Events/SubscriptionUpdatedEvent.cs
+++ b/src/DevBetterWeb.Core/Events/SubscriptionUpdatedEvent.cs
@@ -1,0 +1,14 @@
+﻿using DevBetterWeb.Core.Entities;
+using DevBetterWeb.Core.SharedKernel;
+
+namespace DevBetterWeb.Core.Events;
+
+public class SubscriptionUpdatedEvent : BaseDomainEvent
+{
+  public MemberSubscription MemberSubscription { get; }
+  
+  public SubscriptionUpdatedEvent(MemberSubscription memberSubscription)
+  {
+  	MemberSubscription = memberSubscription;
+  }
+}

--- a/src/DevBetterWeb.Core/Events/SubscriptionUpdatedEvent.cs
+++ b/src/DevBetterWeb.Core/Events/SubscriptionUpdatedEvent.cs
@@ -8,10 +8,10 @@ public class SubscriptionUpdatedEvent : BaseDomainEvent
 {
   public Member Member { get; }
   public MemberSubscription MemberSubscription { get; }
-	
+    
   public SubscriptionUpdatedEvent(Member member, MemberSubscription memberSubscription)
   {
-	Member = Guard.Against.Null(member, nameof(member));
-	MemberSubscription = Guard.Against.Null(memberSubscription, nameof(memberSubscription));
+    Member = Guard.Against.Null(member, nameof(member));
+    MemberSubscription = Guard.Against.Null(memberSubscription, nameof(memberSubscription));
   }
 }

--- a/src/DevBetterWeb.Core/Events/SubscriptionUpdatedEvent.cs
+++ b/src/DevBetterWeb.Core/Events/SubscriptionUpdatedEvent.cs
@@ -1,14 +1,17 @@
-﻿using DevBetterWeb.Core.Entities;
+﻿using Ardalis.GuardClauses;
+using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Core.SharedKernel;
 
 namespace DevBetterWeb.Core.Events;
 
 public class SubscriptionUpdatedEvent : BaseDomainEvent
 {
+  public Member Member { get; }
   public MemberSubscription MemberSubscription { get; }
-  
-  public SubscriptionUpdatedEvent(MemberSubscription memberSubscription)
+	
+  public SubscriptionUpdatedEvent(Member member, MemberSubscription memberSubscription)
   {
-  	MemberSubscription = memberSubscription;
+	Member = Guard.Against.Null(member, nameof(member));
+	MemberSubscription = Guard.Against.Null(memberSubscription, nameof(memberSubscription));
   }
 }

--- a/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogBillingActivityCreatedEventHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogBillingActivityCreatedEventHandler.cs
@@ -16,7 +16,7 @@ public class DiscordLogBillingActivityCreatedEventHandler : IHandle<BillingActiv
   
   public Task Handle(BillingActivityCreatedEvent domainEvent)
   {
-  	_webhook.Content = $"BillingActivity created for member {domainEvent.BillingActivity.Details.MemberName} with action {domainEvent.BillingActivity.Details.ActionVerbPastTense}";
+  	_webhook.Content = $"BillingActivity with action {domainEvent.BillingActivity.Details.ActionVerbPastTense} created for member {domainEvent.BillingActivity.Details.MemberName}";
   	return _webhook.Send();
   }
 }

--- a/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogBillingActivityCreatedEventHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogBillingActivityCreatedEventHandler.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using DevBetterWeb.Core.Events;
+using DevBetterWeb.Core.Interfaces;
+using DevBetterWeb.Infrastructure.DiscordWebooks;
+
+namespace DevBetterWeb.Infrastructure.Handlers;
+
+public class DiscordLogBillingActivityCreatedEventHandler : IHandle<BillingActivityCreatedEvent>
+{
+  private readonly AdminUpdatesWebhook _webhook;
+  
+  public DiscordLogBillingActivityCreatedEventHandler(AdminUpdatesWebhook webhook)
+  {
+  	_webhook = webhook;
+  }
+  
+  public Task Handle(BillingActivityCreatedEvent domainEvent)
+  {
+  	_webhook.Content = $"New BillingActivity created for member {domainEvent.BillingActivity.Details.MemberName} with action {domainEvent.BillingActivity.Details.ActionVerbPastTense}";
+  	return _webhook.Send();
+  }
+}

--- a/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogBillingActivityCreatedEventHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogBillingActivityCreatedEventHandler.cs
@@ -11,12 +11,12 @@ public class DiscordLogBillingActivityCreatedEventHandler : IHandle<BillingActiv
   
   public DiscordLogBillingActivityCreatedEventHandler(AdminUpdatesWebhook webhook)
   {
-  	_webhook = webhook;
+    _webhook = webhook;
   }
   
   public Task Handle(BillingActivityCreatedEvent domainEvent)
   {
-  	_webhook.Content = $"BillingActivity with action {domainEvent.BillingActivity.Details.ActionVerbPastTense} created for member {domainEvent.BillingActivity.Details.MemberName}";
-  	return _webhook.Send();
+    _webhook.Content = $"BillingActivity with action {domainEvent.BillingActivity.Details.ActionVerbPastTense} created for member {domainEvent.BillingActivity.Details.MemberName}";
+    return _webhook.Send();
   }
 }

--- a/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogBillingActivityCreatedEventHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogBillingActivityCreatedEventHandler.cs
@@ -16,7 +16,7 @@ public class DiscordLogBillingActivityCreatedEventHandler : IHandle<BillingActiv
   
   public Task Handle(BillingActivityCreatedEvent domainEvent)
   {
-  	_webhook.Content = $"New BillingActivity created for member {domainEvent.BillingActivity.Details.MemberName} with action {domainEvent.BillingActivity.Details.ActionVerbPastTense}";
+  	_webhook.Content = $"BillingActivity created for member {domainEvent.BillingActivity.Details.MemberName} with action {domainEvent.BillingActivity.Details.ActionVerbPastTense}";
   	return _webhook.Send();
   }
 }

--- a/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionAddedEventHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionAddedEventHandler.cs
@@ -11,12 +11,12 @@ public class DiscordLogSubscriptionAddedEventHandler : IHandle<SubscriptionAdded
   
   public DiscordLogSubscriptionAddedEventHandler(AdminUpdatesWebhook webhook)
   {
-  	_webhook = webhook;
+    _webhook = webhook;
   }
   
   public Task Handle(SubscriptionAddedEvent domainEvent)
   {
-	_webhook.Content = $"Member {domainEvent.Member.UserFullName()} added subscription {domainEvent.MemberSubscription.Id}";
-	return _webhook.Send();
+    _webhook.Content = $"Member {domainEvent.Member.UserFullName()} added subscription {domainEvent.MemberSubscription.Id}";
+    return _webhook.Send();
   }
 }

--- a/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionAddedEventHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionAddedEventHandler.cs
@@ -16,7 +16,7 @@ public class DiscordLogSubscriptionAddedEventHandler : IHandle<SubscriptionAdded
   
   public Task Handle(SubscriptionAddedEvent domainEvent)
   {
-	_webhook.Content = $"Member {domainEvent.MemberSubscription.MemberId} added subscription {domainEvent.MemberSubscription.Id}";
+	_webhook.Content = $"Member {domainEvent.Member.UserFullName()} added subscription {domainEvent.MemberSubscription.Id}";
 	return _webhook.Send();
   }
 }

--- a/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionAddedEventHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionAddedEventHandler.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using DevBetterWeb.Core.Events;
+using DevBetterWeb.Core.Interfaces;
+using DevBetterWeb.Infrastructure.DiscordWebooks;
+
+namespace DevBetterWeb.Infrastructure.Handlers;
+
+public class DiscordLogSubscriptionAddedEventHandler : IHandle<SubscriptionAddedEvent>
+{
+  private readonly AdminUpdatesWebhook _webhook;
+  
+  public DiscordLogSubscriptionAddedEventHandler(AdminUpdatesWebhook webhook)
+  {
+  	_webhook = webhook;
+  }
+  
+  public Task Handle(SubscriptionAddedEvent domainEvent)
+  {
+	_webhook.Content = $"Member {domainEvent.MemberSubscription.MemberId} added subscription {domainEvent.MemberSubscription.Id}";
+	return _webhook.Send();
+  }
+}

--- a/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionUpdatedEventHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionUpdatedEventHandler.cs
@@ -11,12 +11,12 @@ public class DiscordLogSubscriptionUpdatedEventHandler : IHandle<SubscriptionUpd
   
   public DiscordLogSubscriptionUpdatedEventHandler(AdminUpdatesWebhook webhook)
   {
-  	_webhook = webhook;
+    _webhook = webhook;
   }
   
   public Task Handle(SubscriptionUpdatedEvent domainEvent)
   {
-  	_webhook.Content = $"Member {domainEvent.Member.UserFullName()} updated subscription {domainEvent.MemberSubscription.Id}";
-  	return _webhook.Send();
+    _webhook.Content = $"Member {domainEvent.Member.UserFullName()} updated subscription {domainEvent.MemberSubscription.Id}";
+    return _webhook.Send();
   }
 }

--- a/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionUpdatedEventHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionUpdatedEventHandler.cs
@@ -16,7 +16,7 @@ public class DiscordLogSubscriptionUpdatedEventHandler : IHandle<SubscriptionUpd
   
   public Task Handle(SubscriptionUpdatedEvent domainEvent)
   {
-  	_webhook.Content = $"";
+  	_webhook.Content = $"Member {domainEvent.Member.UserFullName()} updated subscription {domainEvent.MemberSubscription.Id}";
   	return _webhook.Send();
   }
 }

--- a/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionUpdatedEventHandler.cs
+++ b/src/DevBetterWeb.Infrastructure/Handlers/DiscordLogSubscriptionUpdatedEventHandler.cs
@@ -1,0 +1,22 @@
+﻿using System.Threading.Tasks;
+using DevBetterWeb.Core.Events;
+using DevBetterWeb.Core.Interfaces;
+using DevBetterWeb.Infrastructure.DiscordWebooks;
+
+namespace DevBetterWeb.Infrastructure.Handlers;
+
+public class DiscordLogSubscriptionUpdatedEventHandler : IHandle<SubscriptionUpdatedEvent>
+{
+  private readonly AdminUpdatesWebhook _webhook;
+  
+  public DiscordLogSubscriptionUpdatedEventHandler(AdminUpdatesWebhook webhook)
+  {
+  	_webhook = webhook;
+  }
+  
+  public Task Handle(SubscriptionUpdatedEvent domainEvent)
+  {
+  	_webhook.Content = $"";
+  	return _webhook.Send();
+  }
+}

--- a/tests/DevBetterWeb.UnitTests/Core/Events/BillingActivityCreatedEventConstructor.cs
+++ b/tests/DevBetterWeb.UnitTests/Core/Events/BillingActivityCreatedEventConstructor.cs
@@ -16,11 +16,11 @@ public class BillingActivityCreatedEventConstructor
 
   public BillingActivityCreatedEventConstructor()
   {
-  	var subscriptionPlanName = Guid.NewGuid().ToString();
-  	var actionVerb = BillingActivityVerb.None;
-  	var billingPeriod = BillingPeriod.Month;
+    var subscriptionPlanName = Guid.NewGuid().ToString();
+    var actionVerb = BillingActivityVerb.None;
+    var billingPeriod = BillingPeriod.Month;
   
-  	_billingActivity = new BillingActivity(_member.Id, new BillingDetails(_member.UserFullName(), subscriptionPlanName, actionVerb, billingPeriod, DateTime.UtcNow));
+    _billingActivity = new BillingActivity(_member.Id, new BillingDetails(_member.UserFullName(), subscriptionPlanName, actionVerb, billingPeriod, DateTime.UtcNow));
   }
 
   [Fact]
@@ -28,17 +28,17 @@ public class BillingActivityCreatedEventConstructor
   {
     var sut = new BillingActivityCreatedEvent(_billingActivity, _member);
 
-	sut.DateOccurred.Should().NotBe(default);
-	sut.Member.Should().Be(_member);
-	sut.BillingActivity.Should().Be(_billingActivity);
+    sut.DateOccurred.Should().NotBe(default);
+    sut.Member.Should().Be(_member);
+    sut.BillingActivity.Should().Be(_billingActivity);
   }
-	
+    
   [Fact]
   public void ShouldThrowExceptionWhenBillingActivityIsNull()
   {
     var action = () => new BillingActivityCreatedEvent(null, _member);
 
-	action.Should().Throw<ArgumentNullException>();
+    action.Should().Throw<ArgumentNullException>();
   }
 
   [Fact]
@@ -46,6 +46,6 @@ public class BillingActivityCreatedEventConstructor
   {
     var action = () => new BillingActivityCreatedEvent(_billingActivity, null);
 
-	action.Should().Throw<ArgumentNullException>();
+    action.Should().Throw<ArgumentNullException>();
   }
 }

--- a/tests/DevBetterWeb.UnitTests/Core/Events/BillingActivityCreatedEventConstructor.cs
+++ b/tests/DevBetterWeb.UnitTests/Core/Events/BillingActivityCreatedEventConstructor.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using DevBetterWeb.Core.Entities;
+using DevBetterWeb.Core.Enums;
+using DevBetterWeb.Core.Events;
+using DevBetterWeb.Core.ValueObjects;
+using DevBetterWeb.UnitTests.Core.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace DevBetterWeb.UnitTests.Core.Events;
+
+public class BillingActivityCreatedEventConstructor
+{
+  private readonly Member _member = MemberHelpers.CreateWithDefaultConstructor();
+  private readonly BillingActivity _billingActivity;
+
+  public BillingActivityCreatedEventConstructor()
+  {
+  	var subscriptionPlanName = Guid.NewGuid().ToString();
+  	var actionVerb = BillingActivityVerb.None;
+  	var billingPeriod = BillingPeriod.Month;
+  
+  	_billingActivity = new BillingActivity(_member.Id, new BillingDetails(_member.UserFullName(), subscriptionPlanName, actionVerb, billingPeriod, DateTime.UtcNow));
+  }
+
+  [Fact]
+  public void ShouldSetValues()
+  {
+    var sut = new BillingActivityCreatedEvent(_billingActivity, _member);
+
+	sut.DateOccurred.Should().NotBe(default);
+	sut.Member.Should().Be(_member);
+	sut.BillingActivity.Should().Be(_billingActivity);
+  }
+	
+  [Fact]
+  public void ShouldThrowExceptionWhenBillingActivityIsNull()
+  {
+    var action = () => new BillingActivityCreatedEvent(null, _member);
+
+	action.Should().Throw<ArgumentNullException>();
+  }
+
+  [Fact]
+  public void ShouldThrowExceptionWhenMemberIsNull()
+  {
+    var action = () => new BillingActivityCreatedEvent(_billingActivity, null);
+
+	action.Should().Throw<ArgumentNullException>();
+  }
+}

--- a/tests/DevBetterWeb.UnitTests/Core/Events/SubscriptionAddedEventConstructor.cs
+++ b/tests/DevBetterWeb.UnitTests/Core/Events/SubscriptionAddedEventConstructor.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using DevBetterWeb.Core.Entities;
+using DevBetterWeb.Core.Events;
+using DevBetterWeb.UnitTests.Core.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace DevBetterWeb.UnitTests.Core.Events;
+
+public class SubscriptionAddedEventConstructor
+{
+  private readonly Member _member = MemberHelpers.CreateWithDefaultConstructor();
+  private readonly MemberSubscription _memberSubscription = SubscriptionHelpers.GetDefaultTestSubscription();
+
+  [Fact]
+  public void ShouldSetValues()
+  {
+    var sut = new SubscriptionAddedEvent(_member, _memberSubscription);
+
+	sut.Member.Should().Be(_member);
+	sut.MemberSubscription.Should().Be(_memberSubscription);
+  }
+
+  [Fact]
+  public void ShouldThrowExceptionWhenMemberIsNull()
+  {
+    var action = () => new SubscriptionAddedEvent(null, _memberSubscription);
+
+	action.Should().Throw<ArgumentNullException>();
+  }
+	
+  [Fact]
+  public void ShouldThrowExceptionWhenMemberSubscriptionIsNull()
+  {
+    var action = () => new SubscriptionAddedEvent(_member, null);
+
+	action.Should().Throw<ArgumentNullException>();
+  }
+}

--- a/tests/DevBetterWeb.UnitTests/Core/Events/SubscriptionAddedEventConstructor.cs
+++ b/tests/DevBetterWeb.UnitTests/Core/Events/SubscriptionAddedEventConstructor.cs
@@ -17,8 +17,8 @@ public class SubscriptionAddedEventConstructor
   {
     var sut = new SubscriptionAddedEvent(_member, _memberSubscription);
 
-	sut.Member.Should().Be(_member);
-	sut.MemberSubscription.Should().Be(_memberSubscription);
+    sut.Member.Should().Be(_member);
+    sut.MemberSubscription.Should().Be(_memberSubscription);
   }
 
   [Fact]
@@ -26,14 +26,14 @@ public class SubscriptionAddedEventConstructor
   {
     var action = () => new SubscriptionAddedEvent(null, _memberSubscription);
 
-	action.Should().Throw<ArgumentNullException>();
+    action.Should().Throw<ArgumentNullException>();
   }
-	
+    
   [Fact]
   public void ShouldThrowExceptionWhenMemberSubscriptionIsNull()
   {
     var action = () => new SubscriptionAddedEvent(_member, null);
 
-	action.Should().Throw<ArgumentNullException>();
+    action.Should().Throw<ArgumentNullException>();
   }
 }

--- a/tests/DevBetterWeb.UnitTests/Core/Events/SubscriptionUpdatedEventConstructor.cs
+++ b/tests/DevBetterWeb.UnitTests/Core/Events/SubscriptionUpdatedEventConstructor.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using DevBetterWeb.Core.Entities;
+using DevBetterWeb.Core.Events;
+using DevBetterWeb.UnitTests.Core.Entities;
+using FluentAssertions;
+using Xunit;
+
+namespace DevBetterWeb.UnitTests.Core.Events;
+
+public class SubscriptionUpdatedEventConstructor
+{
+  private readonly Member _member = MemberHelpers.CreateWithDefaultConstructor();
+  private readonly MemberSubscription _memberSubscription = SubscriptionHelpers.GetDefaultTestSubscription();
+
+  [Fact]
+  public void ShouldSetValues()
+  {
+    var sut = new SubscriptionUpdatedEvent(_member, _memberSubscription);
+
+	sut.Member.Should().Be(_member);
+	sut.MemberSubscription.Should().Be(_memberSubscription);
+  }
+
+  [Fact]
+  public void ShouldThrowExceptionWhenMemberIsNull()
+  {
+    var action = () => new SubscriptionUpdatedEvent(null, _memberSubscription);
+
+	action.Should().Throw<ArgumentNullException>();
+  }
+	
+  [Fact]
+  public void ShouldThrowExceptionWhenMemberSubscriptionIsNull()
+  {
+    var action = () => new SubscriptionUpdatedEvent(_member, null);
+
+	action.Should().Throw<ArgumentNullException>();
+  }
+}

--- a/tests/DevBetterWeb.UnitTests/Core/Events/SubscriptionUpdatedEventConstructor.cs
+++ b/tests/DevBetterWeb.UnitTests/Core/Events/SubscriptionUpdatedEventConstructor.cs
@@ -17,8 +17,8 @@ public class SubscriptionUpdatedEventConstructor
   {
     var sut = new SubscriptionUpdatedEvent(_member, _memberSubscription);
 
-	sut.Member.Should().Be(_member);
-	sut.MemberSubscription.Should().Be(_memberSubscription);
+    sut.Member.Should().Be(_member);
+    sut.MemberSubscription.Should().Be(_memberSubscription);
   }
 
   [Fact]
@@ -26,14 +26,14 @@ public class SubscriptionUpdatedEventConstructor
   {
     var action = () => new SubscriptionUpdatedEvent(null, _memberSubscription);
 
-	action.Should().Throw<ArgumentNullException>();
+    action.Should().Throw<ArgumentNullException>();
   }
-	
+    
   [Fact]
   public void ShouldThrowExceptionWhenMemberSubscriptionIsNull()
   {
     var action = () => new SubscriptionUpdatedEvent(_member, null);
 
-	action.Should().Throw<ArgumentNullException>();
+    action.Should().Throw<ArgumentNullException>();
   }
 }


### PR DESCRIPTION
- Removes profile updated notifications from being sent out to all members in the devbetter-notifications channel when user manages their subscription and billing
- Adds SubscriptionAdded, SubscriptionUpdated, and BillingActivityCreated events that publish discord notifications to the admin updates channel

Fixes #706