### PR TITLE
Fix Discord Webhook issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Head over to [devBetter.com](https://devbetter.com) to see the live site. Scroll
 
 ### Prerequisite
 
+- [.NET 7 SDK](https://dotnet.microsoft.com/en-us/download)
 - [The command-line interface (CLI) tools for Entity Framework Core](https://docs.microsoft.com/en-us/ef/core/cli/dotnet)
 
 ### Building and Running the App Locally
@@ -61,7 +62,7 @@ Some actions, such as registering a member, send email notifications. You should
 
 You should create an **appsettings.development.json** file to hold your other connection strings such as for Azure Storage. You can use [Azurite](https://github.com/Azure/Azurite) as a local emulator for this.
 
-You will need to set up a Discord server - see [here](https://ardalis.com/add-discord-notifications-to-asp-net-core-apps/) for a walkthrough -  and add the url to  appsettings.development.json in the Discord Webhooks section that you can copy from appsettings.json. Alternatively you can create a mock server which will provide you with a url to use - an example is mocky.io
+For the Discord web hook integration, you can use the `dev-test` channel in devBetter's Discord server. The web hook url is in the channel description on Discord. You can use that in you appsettings.development.json. Alternatively, you can set up your own Discord server - see [here](https://ardalis.com/add-discord-notifications-to-asp-net-core-apps/) for a walkthrough -  and add the url to  appsettings.development.json in the Discord Webhooks section that you can copy from appsettings.json. You could also create a mock server which will provide you with a url to use - an example is mocky.io
 
 ## EF Migrations Commands
 

--- a/src/DevBetterWeb.Web/appsettings.Template.json
+++ b/src/DevBetterWeb.Web/appsettings.Template.json
@@ -1,0 +1,56 @@
+{
+  "googleReCaptcha:SiteKey": "6LcEwN4ZAAAAAC-_UfJ0dmdU8bRxLLJ4FwjXyE1R",
+  "googleReCaptcha:SecretKey": "YOUR_SECRET_KEY",
+  "storageconnectionstring": "[connection string goes here]",
+  "VIMEO_TOKEN": "[vimeo token string goes here]",
+  "videoUrlPrefix": "https://devbetter2storage.blob.core.windows.net/videos/",
+  "GoogleMapsAPIKey": "GOOGLE_MAPS_API_KEY",
+  "ConnectionStrings": {
+    "DefaultConnection": "Server=(localdb)\\mssqllocaldb;Database=DevBetterWeb.App;Trusted_Connection=True;MultipleActiveResultSets=true"
+  },
+  "ApiSettings": {
+    "ApiKey": "[api key string goes here]"
+  },
+	"Logging": {
+		"ApplicationInsights": {
+			"LogLevel": {
+				"Default": "Debug",
+				"Microsoft": "Error"
+			}
+		},
+		"IncludeScopes": {},
+		"LogLevel": {
+			"Default": "Debug",
+			"System": "Information",
+			"Microsoft": "Information"
+		},
+		"AzureAppServicesFile": {
+			"IncludeScopes": true,
+			"LogLevel": {
+				"Default": "Information"
+			}
+		}
+	},
+  "DiscordWebhookUrls": {
+    "AdminUpdates": "(test url goes here)",
+    "BookDiscussion": "(test url goes here)",
+    "CoachingSessionsNotifications": "(test url goes here)",
+    "DevBetterComNotifications": "(test url goes here)"
+  },
+	"StripeOptions": {
+		"StripeInvoicePaidWebHookSecretKey": "WebHook key goes here",
+		"StripePaymentIntentSucceededWebHookSecretKey": "WebHook key goes here",
+		"StripeCustomerSubscriptionUpdatedWebHookSecretKey": "WebHook key goes here",
+		"StripeCustomerSubscriptionDeletedWebHookSecretKey": "WebHook key goes here",
+		"StripePublishableKey": "publishable key",
+		"StripeSecretKey": "secret key",
+		"YearlyPlanId": "yearly plan price id",
+		"MonthlyPlanId": "monthly plan price id"
+	},
+  "SubscriptionPlanOptions": {
+    "expectedNumberOfSubscriptionPlansNotInPaymentProvider": 0
+  },
+  "ApplicationInsights": {
+    "ConnectionString": "(appinsights connection string goes here)"
+  }
+}


### PR DESCRIPTION
Discord changed their API so that the `username` property on the request object can no longer be an empty string. We need to make that property a null or not include it at all

closes #1031 