### PR TITLE
Fixing dependency issues

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -54,7 +54,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="all" Version="7.0.10" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="7.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Identity.Core" Version="7.0.13" />
     <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="7.0.13" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.AzureAppServices" Version="7.0.10" />

--- a/src/DevBetterWeb.Core/DevBetterWeb.Core.csproj
+++ b/src/DevBetterWeb.Core/DevBetterWeb.Core.csproj
@@ -20,6 +20,7 @@
 		<PackageReference Include="Ardalis.Specification" />
 		<PackageReference Include="CSharpFunctionalExtensions" />
 		<PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" />
 		<PackageReference Include="NimblePros.Vimeo" />
 		<PackageReference Include="System.ComponentModel.Annotations" />
 		<PackageReference Include="NETStandard.Library" />

--- a/src/DevBetterWeb.Web/DevBetterWeb.Web.csproj
+++ b/src/DevBetterWeb.Web/DevBetterWeb.Web.csproj
@@ -35,6 +35,7 @@
 		<PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
+		<PackageReference Include="Microsoft.Extensions.Identity.Core" />
 		<PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" />
 		<PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" />

--- a/tests/DevBetterWeb.FunctionalTests/DevBetterWeb.FunctionalTests.csproj
+++ b/tests/DevBetterWeb.FunctionalTests/DevBetterWeb.FunctionalTests.csproj
@@ -8,6 +8,7 @@
 
     <ItemGroup>
         <PackageReference Include="MediatR" />
+        <PackageReference Include="Microsoft.Extensions.Identity.Core" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />
         <PackageReference Include="xunit" />
         <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/DevBetterWeb.Tests/DevBetterWeb.Tests.csproj
+++ b/tests/DevBetterWeb.Tests/DevBetterWeb.Tests.csproj
@@ -47,6 +47,7 @@
     <!--<PackageReference Include="Microsoft.CodeCoverage"  />-->
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="NSubstitute" />

--- a/tests/DevBetterWeb.UnitTests/DevBetterWeb.UnitTests.csproj
+++ b/tests/DevBetterWeb.UnitTests/DevBetterWeb.UnitTests.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
     <PackageReference Include="ILogger.Moq" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="Moq" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
This allows us to run locally with the mismatch in package versions.

The problem is Microsoft.Extensions.Identity.Stores uses 7.0.13 but Microsoft.Extensions.Identity.Core is at 7.0.10.  Bringing them both to 7.0.13.