### PR TITLE
#1141 Replace Moq with NSubstitute

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -36,7 +36,6 @@
     <PackageVersion Include="Flurl" Version="3.0.7" />
     <PackageVersion Include="Flurl.Http" Version="3.2.4" />
     <PackageVersion Include="GoogleReCaptcha.V3" Version="1.3.1" />
-    <PackageVersion Include="ILogger.Moq" Version="1.1.10" />
     <PackageVersion Include="Markdig" Version="0.33.0" />
     <PackageVersion Include="MediaInfo.Wrapper.Core" Version="21.9.3" />
     <PackageVersion Include="MediatR" Version="12.1.1" />
@@ -61,7 +60,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.Web.LibraryManager.Build" Version="2.1.175" />
     <PackageVersion Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.13" />
-    <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="NETStandard.Library" Version="2.0.3" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NimblePros.Vimeo" Version="1.0.6" />

--- a/src/DevBetterWeb.Web/Views/Home/Index.cshtml
+++ b/src/DevBetterWeb.Web/Views/Home/Index.cshtml
@@ -369,7 +369,6 @@
                 Join the devBetter group coaching program today and get immediate access to all recorded sessions, the
                 Discord channel,
                 the web site resources, the private GitHub, the private Stack Overflow team, and more!
-                </a>
             </p>
             <div style="width: 100%; text-align: center; margin-top: 10px; margin-bottom: 20px;">
                 <a class="btn btn-primary" href="/checkout/monthly">

--- a/tests/DevBetterWeb.Tests/DevBetterWeb.Tests.csproj
+++ b/tests/DevBetterWeb.Tests/DevBetterWeb.Tests.csproj
@@ -49,7 +49,6 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
     <PackageReference Include="NSubstitute" />
     <PackageReference Include="ReportGenerator" />
     <PackageReference Include="xunit" />

--- a/tests/DevBetterWeb.Tests/Services/AlumniGraduationServiceTests/CheckIfAnyMemberGraduating.cs
+++ b/tests/DevBetterWeb.Tests/Services/AlumniGraduationServiceTests/CheckIfAnyMemberGraduating.cs
@@ -5,17 +5,17 @@ using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Core.Interfaces;
 using DevBetterWeb.Core.ValueObjects;
 using DevBetterWeb.Infrastructure.Services;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.Tests.Services.AlumniGraduationServiceTests;
 
 public class CheckIfAnyMemberGraduating
 {
-  private readonly Mock<IUserLookupService> userLookupService;
-  private readonly Mock<IRepository<Member>> repository;
-  private readonly Mock<IGraduationCommunicationsService> graduationCommunications;
-  private readonly Mock<IUserRoleManager> userManager;
+  private readonly IUserLookupService userLookupService;
+  private readonly IRepository<Member> repository;
+  private readonly IGraduationCommunicationsService graduationCommunications;
+  private readonly IUserRoleManager userManager;
 
   private const int DAYS_IN_TWO_YEARS = 365 * 2;
 
@@ -23,11 +23,11 @@ public class CheckIfAnyMemberGraduating
 
   public CheckIfAnyMemberGraduating()
   {
-    userLookupService = new Mock<IUserLookupService>();
-    repository = new Mock<IRepository<Member>>();
-    graduationCommunications = new Mock<IGraduationCommunicationsService>();
-    userManager = new Mock<IUserRoleManager>();
-    service = new AlumniGraduationService(userLookupService.Object, repository.Object, graduationCommunications.Object, userManager.Object);
+    userLookupService = Substitute.For<IUserLookupService>();
+    repository = Substitute.For<IRepository<Member>>();
+    graduationCommunications = Substitute.For<IGraduationCommunicationsService>();
+    userManager = Substitute.For<IUserRoleManager>();
+    service = new AlumniGraduationService(userLookupService, repository, graduationCommunications, userManager);
   }
 
   [Fact]
@@ -47,7 +47,7 @@ public class CheckIfAnyMemberGraduating
     var graduatingMember = GetGraduatingMember();
     testlist.Add(graduatingMember);
 
-    userLookupService.Setup(u => u.FindUserIsAlumniByUserIdAsync(graduatingMember.UserId)).ReturnsAsync(false);
+    userLookupService.FindUserIsAlumniByUserIdAsync(graduatingMember.UserId).Returns(false);
 
     var list = await service.CheckIfAnyMemberGraduating(testlist);
 
@@ -65,7 +65,7 @@ public class CheckIfAnyMemberGraduating
     var nonGraduatingMember = GetNonGraduatingMember();
     testlist.Add(nonGraduatingMember);
 
-    userLookupService.Setup(u => u.FindUserIsAlumniByUserIdAsync(graduatingMember.UserId)).ReturnsAsync(false);
+    userLookupService.FindUserIsAlumniByUserIdAsync(graduatingMember.UserId).Returns(false);
 
     var list = await service.CheckIfAnyMemberGraduating(testlist);
 
@@ -92,7 +92,7 @@ public class CheckIfAnyMemberGraduating
     var alum = GetGraduatingMember();
     testlist.Add(alum);
 
-    userLookupService.Setup(u => u.FindUserIsAlumniByUserIdAsync(alum.UserId)).ReturnsAsync(true);
+    userLookupService.FindUserIsAlumniByUserIdAsync(alum.UserId).Returns(true);
 
     var list = await service.CheckIfAnyMemberGraduating(testlist);
 
@@ -109,7 +109,7 @@ public class CheckIfAnyMemberGraduating
     member.MemberSubscriptions.Add(nearGraduationSubscription);
     testlist.Add(member);
 
-    userLookupService.Setup(u => u.FindUserIsAlumniByUserIdAsync(member.UserId)).ReturnsAsync(false);
+    userLookupService.FindUserIsAlumniByUserIdAsync(member.UserId).Returns(false);
 
     var list = await service.CheckIfAnyMemberGraduating(testlist);
 

--- a/tests/DevBetterWeb.Tests/Services/DailyCheckPingServiceTests/CheckIfAnyActiveInvitationsRequireAdminPing.cs
+++ b/tests/DevBetterWeb.Tests/Services/DailyCheckPingServiceTests/CheckIfAnyActiveInvitationsRequireAdminPing.cs
@@ -4,17 +4,17 @@ using DevBetterWeb.Core.Interfaces;
 using DevBetterWeb.Infrastructure.Identity.Data;
 using DevBetterWeb.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.Tests.Services.DailyCheckPingServiceTests;
 
 public class CheckIfAnyActiveInvitationsRequireAdminPing
 {
-  private readonly Mock<IRepository<Invitation>> _repository = new();
-  private readonly Mock<IRepository<Member>> _memberRepository = new();
-  private readonly Mock<IEmailService> _emailService = new();
-  private readonly Mock<UserManager<ApplicationUser>> _userManager;
+  private readonly IRepository<Invitation> _repository = Substitute.For<IRepository<Invitation>>();
+  private readonly IRepository<Member> _memberRepository = Substitute.For<IRepository<Member>>();
+  private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+  private readonly UserManager<ApplicationUser> _userManager;
 
   private DailyCheckPingService _service;
 
@@ -23,9 +23,9 @@ public class CheckIfAnyActiveInvitationsRequireAdminPing
 
   public CheckIfAnyActiveInvitationsRequireAdminPing()
   {
-    var store = new Mock<IUserStore<ApplicationUser>>();
-    _userManager = new Mock<UserManager<ApplicationUser>>(store.Object, null, null, null, null, null, null, null, null);
-    _service = new DailyCheckPingService(_repository.Object, _memberRepository.Object, _emailService.Object, _userManager.Object);
+    var store = Substitute.For<IUserStore<ApplicationUser>>();
+    _userManager = Substitute.For<UserManager<ApplicationUser>>(store, null, null, null, null, null, null, null, null);
+    _service = new DailyCheckPingService(_repository, _memberRepository, _emailService, _userManager);
   }
 
   [Fact]

--- a/tests/DevBetterWeb.Tests/Services/DailyCheckPingServiceTests/CheckIfAnyActiveInvitationsRequireUserPing.cs
+++ b/tests/DevBetterWeb.Tests/Services/DailyCheckPingServiceTests/CheckIfAnyActiveInvitationsRequireUserPing.cs
@@ -4,17 +4,17 @@ using DevBetterWeb.Core.Interfaces;
 using DevBetterWeb.Infrastructure.Identity.Data;
 using DevBetterWeb.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.Tests.Services.DailyCheckPingServiceTests;
 
 public class CheckIfAnyActiveInvitationsRequireUserPing
 {
-  private readonly Mock<IRepository<Invitation>> _repository = new();
-  private readonly Mock<IRepository<Member>> _membrRepository = new();
-  private readonly Mock<IEmailService> _emailService = new();
-  private readonly Mock<UserManager<ApplicationUser>> _userManager;
+  private readonly IRepository<Invitation> _repository = Substitute.For<IRepository<Invitation>>();
+  private readonly IRepository<Member> _membrRepository = Substitute.For<IRepository<Member>>();
+  private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+  private readonly UserManager<ApplicationUser> _userManager;
 
   private DailyCheckPingService _service;
 
@@ -23,10 +23,10 @@ public class CheckIfAnyActiveInvitationsRequireUserPing
 
   public CheckIfAnyActiveInvitationsRequireUserPing()
   {
-    var store = new Mock<IUserStore<ApplicationUser>>();
-    _userManager = new Mock<UserManager<ApplicationUser>>(store.Object, null, null, null, null, null, null, null, null);
+    var store = Substitute.For<IUserStore<ApplicationUser>>();
+    _userManager = Substitute.For<UserManager<ApplicationUser>>(store, null, null, null, null, null, null, null, null);
 
-    _service = new DailyCheckPingService(_repository.Object, _membrRepository.Object, _emailService.Object, _userManager.Object);
+    _service = new DailyCheckPingService(_repository, _membrRepository, _emailService, _userManager);
   }
 
   [Fact]

--- a/tests/DevBetterWeb.Tests/Services/MemberSubscriptionCancellationServiceTests/MemberSubscriptionCancellationServiceTest.cs
+++ b/tests/DevBetterWeb.Tests/Services/MemberSubscriptionCancellationServiceTests/MemberSubscriptionCancellationServiceTest.cs
@@ -1,30 +1,30 @@
 ﻿using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Core.Interfaces;
 using DevBetterWeb.Core.Services;
-using Moq;
+using NSubstitute;
 
 namespace DevBetterWeb.Tests.Services.MemberSubscriptionCancellationServiceTests;
 
 public class MemberSubscriptionCancellationServiceTest
 {
-  internal readonly Mock<IUserRoleMembershipService> _userRoleMembershipService;
-  internal readonly Mock<IEmailService> _emailService;
-  internal readonly Mock<IUserLookupService> _userLookup;
-  internal readonly Mock<IMemberLookupService> _memberLookup;
-  internal readonly Mock<IRepository<Member>> _memberRepository;
-  internal readonly Mock<IMemberSubscriptionPeriodCalculationsService> _subscriptionPeriodCalculationsService;
+  protected readonly IUserRoleMembershipService _userRoleMembershipService;
+  protected readonly IEmailService _emailService;
+  protected readonly IUserLookupService _userLookup;
+  protected readonly IMemberLookupService _memberLookup;
+  protected readonly IRepository<Member> _memberRepository;
+  protected readonly IMemberSubscriptionPeriodCalculationsService _subscriptionPeriodCalculationsService;
 
   internal readonly IMemberCancellationService _memberCancellationService;
 
   public MemberSubscriptionCancellationServiceTest()
   {
-    _userRoleMembershipService = new Mock<IUserRoleMembershipService>();
-    _emailService = new Mock<IEmailService>();
-    _userLookup = new Mock<IUserLookupService>();
-    _memberLookup = new Mock<IMemberLookupService>();
-    _memberRepository = new Mock<IRepository<Member>>();
-    _subscriptionPeriodCalculationsService = new Mock<IMemberSubscriptionPeriodCalculationsService>();
-    _memberCancellationService = new MemberSubscriptionCancellationService(_userRoleMembershipService.Object,
-      _emailService.Object, _userLookup.Object, _memberLookup.Object, _memberRepository.Object, _subscriptionPeriodCalculationsService.Object);
+    _userRoleMembershipService = Substitute.For<IUserRoleMembershipService>();
+    _emailService = Substitute.For<IEmailService>();
+    _userLookup = Substitute.For<IUserLookupService>();
+    _memberLookup = Substitute.For<IMemberLookupService>();
+    _memberRepository = Substitute.For<IRepository<Member>>();
+    _subscriptionPeriodCalculationsService = Substitute.For<IMemberSubscriptionPeriodCalculationsService>();
+    _memberCancellationService = new MemberSubscriptionCancellationService(_userRoleMembershipService,
+      _emailService, _userLookup, _memberLookup, _memberRepository, _subscriptionPeriodCalculationsService);
   }
 }

--- a/tests/DevBetterWeb.Tests/Services/MemberSubscriptionCancellationServiceTests/RemoveUserFromMemberRoleAsync.cs
+++ b/tests/DevBetterWeb.Tests/Services/MemberSubscriptionCancellationServiceTests/RemoveUserFromMemberRoleAsync.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 using DevBetterWeb.Core;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.Tests.Services.MemberSubscriptionCancellationServiceTests;
@@ -13,12 +13,10 @@ public class RemoveUserFromMemberRoleAsync : MemberSubscriptionCancellationServi
   [Fact]
   public async Task RemovesUserFromMemberRole()
   {
-    _userLookup.Setup(u => u.FindUserIdByEmailAsync(_email)).ReturnsAsync(_userId);
+	  _userLookup.FindUserIdByEmailAsync(_email).Returns(_userId);
 
     await _memberCancellationService.RemoveUserFromMemberRoleAsync(_email);
 
-    _userRoleMembershipService.Verify(u => u.RemoveUserFromRoleByRoleNameAsync(_userId, Constants.MEMBER_ROLE_NAME), Times.Once);
+    await _userRoleMembershipService.Received(1).RemoveUserFromRoleByRoleNameAsync(_userId, Constants.MEMBER_ROLE_NAME);
   }
 }
-
-

--- a/tests/DevBetterWeb.Tests/Services/MemberSubscriptionCancellationServiceTests/SendCancellationEmailAsync.cs
+++ b/tests/DevBetterWeb.Tests/Services/MemberSubscriptionCancellationServiceTests/SendCancellationEmailAsync.cs
@@ -1,5 +1,5 @@
 ﻿using System.Threading.Tasks;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.Tests.Services.MemberSubscriptionCancellationServiceTests;
@@ -13,8 +13,6 @@ public class SendCancellationEmailAsync : MemberSubscriptionCancellationServiceT
   {
     await _memberCancellationService.SendCancellationEmailAsync(_email);
 
-    _emailService.Verify(e => e.SendEmailAsync(_email, It.IsAny<string>(), It.IsAny<string>()));
+    await _emailService.Received(1).SendEmailAsync(_email, Arg.Any<string>(), Arg.Any<string>());
   }
 }
-
-

--- a/tests/DevBetterWeb.Tests/Services/MemberSubscriptionCancellationServiceTests/SendFutureCancellationEmailAsync.cs
+++ b/tests/DevBetterWeb.Tests/Services/MemberSubscriptionCancellationServiceTests/SendFutureCancellationEmailAsync.cs
@@ -3,7 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Core.Specs;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.Tests.Services.MemberSubscriptionCancellationServiceTests;
@@ -16,11 +16,11 @@ public class SendFutureCancellationEmailAsync : MemberSubscriptionCancellationSe
   [Fact]
   public async Task SendsEmail()
   {
-    _memberRepository.Setup(s => s.FirstOrDefaultAsync(It.IsAny<MemberByUserIdSpec>(), CancellationToken.None)).ReturnsAsync(new Member());
-    _subscriptionPeriodCalculationsService.Setup(s => s.GetCurrentSubscriptionEndDate(It.IsAny<Member>())).Returns(_date);
+    _memberRepository.FirstOrDefaultAsync(Arg.Any<MemberByUserIdSpec>(), CancellationToken.None).Returns(new Member());
+    _subscriptionPeriodCalculationsService.GetCurrentSubscriptionEndDate(Arg.Any<Member>()).Returns(_date);
 
     await _memberCancellationService.SendFutureCancellationEmailAsync(_email);
 
-    _emailService.Verify(e => e.SendEmailAsync(_email, It.IsAny<string>(), It.IsAny<string>()));
+    await _emailService.Received(1).SendEmailAsync(_email, Arg.Any<string>(), Arg.Any<string>());
   }
 }

--- a/tests/DevBetterWeb.Tests/Services/MemberSubscriptionEndedAdminEmailServiceTests/SendMemberSubscriptionEndedEmailAsync.cs
+++ b/tests/DevBetterWeb.Tests/Services/MemberSubscriptionEndedAdminEmailServiceTests/SendMemberSubscriptionEndedEmailAsync.cs
@@ -6,7 +6,7 @@ using DevBetterWeb.Core.Interfaces;
 using DevBetterWeb.Infrastructure.Identity.Data;
 using DevBetterWeb.Infrastructure.Services;
 using Microsoft.AspNetCore.Identity;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.Tests.Services.MemberSubscriptionEndedAdminEmailServiceTests;
@@ -15,30 +15,30 @@ public class SendMemberSubscriptionEndedEmailAsync
 {
   private readonly MemberSubscriptionEndedAdminEmailService _memberSubscriptionEndedAdminEmailService;
 
-  private readonly Mock<UserManager<ApplicationUser>> _userManager;
-  private readonly Mock<IEmailService> _emailService;
-  private readonly Mock<IMemberLookupService> _memberLookup;
+  private readonly UserManager<ApplicationUser> _userManager;
+  private readonly IEmailService _emailService;
+  private readonly IMemberLookupService _memberLookup;
 
   public SendMemberSubscriptionEndedEmailAsync()
   {
-    var store = new Mock<IUserStore<ApplicationUser>>();
-    _userManager = new Mock<UserManager<ApplicationUser>>(store.Object, null, null, null, null, null, null, null, null);
-    _emailService = new Mock<IEmailService>();
-    _memberLookup = new Mock<IMemberLookupService>();
+    var store = Substitute.For<IUserStore<ApplicationUser>>();
+    _userManager = Substitute.For<UserManager<ApplicationUser>>(store, null, null, null, null, null, null, null, null);
+    _emailService = Substitute.For<IEmailService>();
+    _memberLookup = Substitute.For<IMemberLookupService>();
     _memberSubscriptionEndedAdminEmailService = new MemberSubscriptionEndedAdminEmailService(
-      _userManager.Object, _emailService.Object, _memberLookup.Object);
+      _userManager, _emailService, _memberLookup);
   }
 
   [Fact]
   public async Task SendsEmail()
   {
-    _memberLookup.Setup(m => m.GetMemberByEmailAsync(It.IsAny<string>())).ReturnsAsync(new Mock<Member>().Object);
-    _userManager.Setup(u => u.GetUsersInRoleAsync(AuthConstants.Roles.ADMINISTRATORS)).ReturnsAsync(
-      new List<ApplicationUser> { new Mock<ApplicationUser>().Object, new Mock<ApplicationUser>().Object });
+    _memberLookup.GetMemberByEmailAsync(Arg.Any<string>()).Returns(Substitute.For<Member>());
+    _userManager.GetUsersInRoleAsync(AuthConstants.Roles.ADMINISTRATORS).Returns(
+      new List<ApplicationUser> { Substitute.For<ApplicationUser>(), Substitute.For<ApplicationUser>() });
 
     string testEmail = "TestEmail";
     await _memberSubscriptionEndedAdminEmailService.SendMemberSubscriptionEndedEmailAsync(testEmail, null);
 
-    _emailService.Verify(e => e.SendEmailAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()), Times.Exactly(2));
+    await _emailService.Received(2).SendEmailAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
   }
 }

--- a/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/CreateInvitation.cs
+++ b/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/CreateInvitation.cs
@@ -3,20 +3,19 @@ using System.Threading.Tasks;
 using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Core.Interfaces;
 using DevBetterWeb.Core.Services;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.Tests.Services.NewMemberServiceTests;
 
 public class CreateInvitation
 {
-  private readonly Mock<IRepository<Member>> _memberRepository = new();
-  private readonly Mock<IRepository<Invitation>> _invitationRepository = new();
-  private readonly Mock<IUserRoleMembershipService> _userRoleMembershipService = new();
-  private readonly Mock<IPaymentHandlerSubscription> _paymentHandlerSubscription = new();
-  private readonly Mock<IEmailService> _emailService = new();
-  private readonly Mock<IMemberRegistrationService> _memberRegistrationService = new();
-  private readonly Mock<IAppLogger<NewMemberService>> _logger = new();
+  private readonly IRepository<Invitation> _invitationRepository = Substitute.For<IRepository<Invitation>>();
+  private readonly IUserRoleMembershipService _userRoleMembershipService = Substitute.For<IUserRoleMembershipService>();
+  private readonly IPaymentHandlerSubscription _paymentHandlerSubscription = Substitute.For<IPaymentHandlerSubscription>();
+  private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+  private readonly IMemberRegistrationService _memberRegistrationService = Substitute.For<IMemberRegistrationService>();
+  private readonly IAppLogger<NewMemberService> _logger = Substitute.For<IAppLogger<NewMemberService>>();
 
   private readonly INewMemberService _newMemberService;
 
@@ -25,12 +24,12 @@ public class CreateInvitation
 
   public CreateInvitation()
   {
-    _newMemberService = new NewMemberService(_invitationRepository.Object,
-    _userRoleMembershipService.Object,
-    _paymentHandlerSubscription.Object,
-    _emailService.Object,
-    _memberRegistrationService.Object,
-    _logger.Object,
+    _newMemberService = new NewMemberService(_invitationRepository,
+    _userRoleMembershipService,
+    _paymentHandlerSubscription,
+    _emailService,
+    _memberRegistrationService,
+    _logger,
             null!); // TODO: Add dependency
 
   }
@@ -43,6 +42,6 @@ public class CreateInvitation
     Assert.Equal(_email, invitation.Email);
     Assert.Equal(_subscriptionId, invitation.PaymentHandlerSubscriptionId);
 
-    _invitationRepository.Verify(r => r.AddAsync(invitation, CancellationToken.None), Times.Once);
+    await _invitationRepository.Received(1).AddAsync(invitation, CancellationToken.None);
   }
 }

--- a/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/MemberSetup.cs
+++ b/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/MemberSetup.cs
@@ -62,7 +62,7 @@ public class MemberSetup
     Assert.Equal(_firstName, member.FirstName);
     Assert.Equal(_lastName, member.LastName);
 
-    _userRoleMembershipService.Received(1).AddUserToRoleByRoleNameAsync(_userId, _roleName);
+    await _userRoleMembershipService.Received(1).AddUserToRoleByRoleNameAsync(_userId, _roleName);
     Assert.False(_invitation.Active);
   }
 }

--- a/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/MemberSetup.cs
+++ b/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/MemberSetup.cs
@@ -5,21 +5,21 @@ using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Core.Interfaces;
 using DevBetterWeb.Core.Services;
 using DevBetterWeb.Core.Specs;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.Tests.Services.NewMemberServiceTests;
 
 public class MemberSetup
 {
-  private readonly Mock<IRepository<Member>> _memberRepository = new();
-  private readonly Mock<IRepository<Invitation>> _invitationRepository = new();
-  private readonly Mock<IUserRoleMembershipService> _userRoleMembershipService = new();
-  private readonly Mock<IPaymentHandlerSubscription> _paymentHandlerSubscription = new();
-  private readonly Mock<IEmailService> _emailService = new();
-  private readonly Mock<IMemberRegistrationService> _memberRegistrationService = new();
-  private readonly Mock<IAppLogger<NewMemberService>> _logger = new();
-  private readonly Mock<IMemberAddBillingActivityService> _memberAddBillingActivityService = new();
+  private readonly IRepository<Member> _memberRepository = Substitute.For<IRepository<Member>>();
+  private readonly IRepository<Invitation> _invitationRepository = Substitute.For<IRepository<Invitation>>();
+  private readonly IUserRoleMembershipService _userRoleMembershipService = Substitute.For<IUserRoleMembershipService>();
+  private readonly IPaymentHandlerSubscription _paymentHandlerSubscription = Substitute.For<IPaymentHandlerSubscription>();
+  private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+  private readonly IMemberRegistrationService _memberRegistrationService = Substitute.For<IMemberRegistrationService>();
+  private readonly IAppLogger<NewMemberService> _logger = Substitute.For<IAppLogger<NewMemberService>>();
+  private readonly IMemberAddBillingActivityService _memberAddBillingActivityService = Substitute.For<IMemberAddBillingActivityService>();
 
   private readonly INewMemberService _newMemberService;
 
@@ -36,13 +36,13 @@ public class MemberSetup
 
   public MemberSetup()
   {
-    _newMemberService = new NewMemberService(_invitationRepository.Object,
-      _userRoleMembershipService.Object,
-      _paymentHandlerSubscription.Object,
-      _emailService.Object,
-      _memberRegistrationService.Object,
-      _logger.Object,
-      _memberAddBillingActivityService.Object);
+    _newMemberService = new NewMemberService(_invitationRepository,
+      _userRoleMembershipService,
+      _paymentHandlerSubscription,
+      _emailService,
+      _memberRegistrationService,
+      _logger,
+      _memberAddBillingActivityService);
     _invitation = new Invitation(_email, _inviteCode, _subscriptionId);
   }
 
@@ -52,17 +52,17 @@ public class MemberSetup
     var memberResult = new Member();
     var memberId = memberResult.Id;
 
-    _invitationRepository.Setup(r => r.FirstOrDefaultAsync(It.IsAny<InvitationByInviteCodeSpec>(), CancellationToken.None)).ReturnsAsync(_invitation);
-    _invitationRepository.Setup(r => r.ListAsync(It.IsAny<ActiveInvitationByEmailSpec>(), CancellationToken.None)).ReturnsAsync(new List<Invitation>());
-    _memberRepository.Setup(r => r.GetByIdAsync(memberId, CancellationToken.None)).ReturnsAsync(memberResult);
-    _memberRegistrationService.Setup(r => r.RegisterMemberAsync(_userId)).ReturnsAsync(memberResult);
+    _invitationRepository.FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None).Returns(_invitation);
+    _invitationRepository.ListAsync(Arg.Any<ActiveInvitationByEmailSpec>(), CancellationToken.None).Returns(new List<Invitation>());
+    _memberRepository.GetByIdAsync(memberId, CancellationToken.None).Returns(memberResult);
+    _memberRegistrationService.RegisterMemberAsync(_userId).Returns(memberResult);
 
     Member member = await _newMemberService.MemberSetupAsync(_userId, _firstName, _lastName, _inviteCode, "");
 
     Assert.Equal(_firstName, member.FirstName);
     Assert.Equal(_lastName, member.LastName);
 
-    _userRoleMembershipService.Verify(u => u.AddUserToRoleByRoleNameAsync(_userId, _roleName), Times.Once);
+    _userRoleMembershipService.Received(1).AddUserToRoleByRoleNameAsync(_userId, _roleName);
     Assert.False(_invitation.Active);
   }
 }

--- a/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/SendRegistrationEmail.cs
+++ b/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/SendRegistrationEmail.cs
@@ -2,20 +2,20 @@
 using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Core.Interfaces;
 using DevBetterWeb.Core.Services;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.Tests.Services.NewMemberServiceTests;
 
 public class SendRegistrationEmail
 {
-  private readonly Mock<IRepository<Member>> _memberRepository = new();
-  private readonly Mock<IRepository<Invitation>> _invitationRepository = new();
-  private readonly Mock<IUserRoleMembershipService> _userRoleMembershipService = new();
-  private readonly Mock<IPaymentHandlerSubscription> _paymentHandlerSubscription = new();
-  private readonly Mock<IEmailService> _emailService = new();
-  private readonly Mock<IMemberRegistrationService> _memberRegistrationService = new();
-  private readonly Mock<IAppLogger<NewMemberService>> _logger = new();
+  private readonly IRepository<Member> _memberRepository = Substitute.For<IRepository<Member>>();
+  private readonly IRepository<Invitation> _invitationRepository = Substitute.For<IRepository<Invitation>>();
+  private readonly IUserRoleMembershipService _userRoleMembershipService = Substitute.For<IUserRoleMembershipService>();
+  private readonly IPaymentHandlerSubscription _paymentHandlerSubscription = Substitute.For<IPaymentHandlerSubscription>();
+  private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+  private readonly IMemberRegistrationService _memberRegistrationService = Substitute.For<IMemberRegistrationService>();
+  private readonly IAppLogger<NewMemberService> _logger = Substitute.For<IAppLogger<NewMemberService>>();
 
   private readonly INewMemberService _newMemberService;
 
@@ -27,12 +27,12 @@ public class SendRegistrationEmail
 
   public SendRegistrationEmail()
   {
-    _newMemberService = new NewMemberService(_invitationRepository.Object,
-      _userRoleMembershipService.Object,
-      _paymentHandlerSubscription.Object,
-      _emailService.Object,
-      _memberRegistrationService.Object,
-      _logger.Object,
+    _newMemberService = new NewMemberService(_invitationRepository,
+      _userRoleMembershipService,
+      _paymentHandlerSubscription,
+      _emailService,
+      _memberRegistrationService,
+      _logger,
               null!); // TODO: Add dependency
 
     _invitation = new Invitation(_email, _inviteCode, _subscriptionId);
@@ -43,7 +43,7 @@ public class SendRegistrationEmail
   {
     await _newMemberService.SendRegistrationEmailAsync(_invitation);
 
-    _emailService.Verify(e => e.SendEmailAsync(_email, It.IsAny<string>(), It.IsAny<string>()), Times.Once);
+    _emailService.Received(1).SendEmailAsync(_email, Arg.Any<string>(), Arg.Any<string>());
   }
 
 }

--- a/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/SendRegistrationEmail.cs
+++ b/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/SendRegistrationEmail.cs
@@ -9,7 +9,6 @@ namespace DevBetterWeb.Tests.Services.NewMemberServiceTests;
 
 public class SendRegistrationEmail
 {
-  private readonly IRepository<Member> _memberRepository = Substitute.For<IRepository<Member>>();
   private readonly IRepository<Invitation> _invitationRepository = Substitute.For<IRepository<Invitation>>();
   private readonly IUserRoleMembershipService _userRoleMembershipService = Substitute.For<IUserRoleMembershipService>();
   private readonly IPaymentHandlerSubscription _paymentHandlerSubscription = Substitute.For<IPaymentHandlerSubscription>();
@@ -43,7 +42,7 @@ public class SendRegistrationEmail
   {
     await _newMemberService.SendRegistrationEmailAsync(_invitation);
 
-    _emailService.Received(1).SendEmailAsync(_email, Arg.Any<string>(), Arg.Any<string>());
+    await _emailService.Received(1).SendEmailAsync(_email, Arg.Any<string>(), Arg.Any<string>());
   }
 
 }

--- a/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/VerifyValidEmailAndInviteCode.cs
+++ b/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/VerifyValidEmailAndInviteCode.cs
@@ -69,12 +69,7 @@ public class VerifyValidEmailAndInviteCode
   [Fact]
   public async Task ReturnsExceptionMessageGivenInvalidInviteCode()
   {
-
-#pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
-#pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-    _ = _invitationRepository.FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None).Returns((Invitation)null);
-#pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
-#pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
+    _ = _invitationRepository.FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None).Returns((Invitation)null!);
 
     var result = await _newMemberService.VerifyValidEmailAndInviteCodeAsync(_email, _inviteCode);
 

--- a/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/VerifyValidEmailAndInviteCode.cs
+++ b/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/VerifyValidEmailAndInviteCode.cs
@@ -11,7 +11,6 @@ namespace DevBetterWeb.Tests.Services.NewMemberServiceTests;
 
 public class VerifyValidEmailAndInviteCode
 {
-  private readonly IRepository<Member> _memberRepository = Substitute.For<IRepository<Member>>();
   private readonly IRepository<Invitation> _invitationRepository = Substitute.For<IRepository<Invitation>>();
   private readonly IUserRoleMembershipService _userRoleMembershipService = Substitute.For<IUserRoleMembershipService>();
   private readonly IPaymentHandlerSubscription _paymentHandlerSubscription = Substitute.For<IPaymentHandlerSubscription>();
@@ -50,7 +49,7 @@ public class VerifyValidEmailAndInviteCode
 
     var result = await _newMemberService.VerifyValidEmailAndInviteCodeAsync(_email, _inviteCode);
 
-    _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
+    await _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
     Assert.Equal(_validEmailAndInviteCodeString, result.Value);
   }
 
@@ -63,7 +62,7 @@ public class VerifyValidEmailAndInviteCode
 
     var result = await _newMemberService.VerifyValidEmailAndInviteCodeAsync(_email, _inviteCode);
 
-    _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
+    await _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
     Assert.Equal(_invalidEmailString, result.Value);
   }
 
@@ -79,22 +78,22 @@ public class VerifyValidEmailAndInviteCode
 
     var result = await _newMemberService.VerifyValidEmailAndInviteCodeAsync(_email, _inviteCode);
 
-    _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
+    await _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
     Assert.Equal(_invalidInviteCodeString, result.Value);
   }
 
   [Fact]
   public async Task ReturnsExceptionMessageGivenInactiveInviteCode()
   {
-    Invitation _invitation = new Invitation(_email, _inviteCode, _subscriptionId);
+    Invitation invitation = new Invitation(_email, _inviteCode, _subscriptionId);
 
-    _invitation.Deactivate();
+    invitation.Deactivate();
 
-    _invitationRepository.FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None).Returns(_invitation);
+    _invitationRepository.FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None).Returns(invitation);
 
     var result = await _newMemberService.VerifyValidEmailAndInviteCodeAsync(_email, _inviteCode);
 
-    _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
+    await _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
     Assert.Equal(_inactiveInviteString, result.Value);
   }
 }

--- a/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/VerifyValidEmailAndInviteCode.cs
+++ b/tests/DevBetterWeb.Tests/Services/NewMemberServiceTests/VerifyValidEmailAndInviteCode.cs
@@ -4,20 +4,20 @@ using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Core.Interfaces;
 using DevBetterWeb.Core.Services;
 using DevBetterWeb.Core.Specs;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.Tests.Services.NewMemberServiceTests;
 
 public class VerifyValidEmailAndInviteCode
 {
-  private readonly Mock<IRepository<Member>> _memberRepository = new();
-  private readonly Mock<IRepository<Invitation>> _invitationRepository = new();
-  private readonly Mock<IUserRoleMembershipService> _userRoleMembershipService = new();
-  private readonly Mock<IPaymentHandlerSubscription> _paymentHandlerSubscription = new();
-  private readonly Mock<IEmailService> _emailService = new();
-  private readonly Mock<IMemberRegistrationService> _memberRegistrationService = new();
-  private readonly Mock<IAppLogger<NewMemberService>> _logger = new();
+  private readonly IRepository<Member> _memberRepository = Substitute.For<IRepository<Member>>();
+  private readonly IRepository<Invitation> _invitationRepository = Substitute.For<IRepository<Invitation>>();
+  private readonly IUserRoleMembershipService _userRoleMembershipService = Substitute.For<IUserRoleMembershipService>();
+  private readonly IPaymentHandlerSubscription _paymentHandlerSubscription = Substitute.For<IPaymentHandlerSubscription>();
+  private readonly IEmailService _emailService = Substitute.For<IEmailService>();
+  private readonly IMemberRegistrationService _memberRegistrationService = Substitute.For<IMemberRegistrationService>();
+  private readonly IAppLogger<NewMemberService> _logger = Substitute.For<IAppLogger<NewMemberService>>();
 
   private readonly INewMemberService _newMemberService;
 
@@ -32,12 +32,12 @@ public class VerifyValidEmailAndInviteCode
 
   public VerifyValidEmailAndInviteCode()
   {
-    _newMemberService = new NewMemberService(_invitationRepository.Object,
-      _userRoleMembershipService.Object,
-      _paymentHandlerSubscription.Object,
-      _emailService.Object,
-      _memberRegistrationService.Object,
-      _logger.Object,
+    _newMemberService = new NewMemberService(_invitationRepository,
+      _userRoleMembershipService,
+      _paymentHandlerSubscription,
+      _emailService,
+      _memberRegistrationService,
+      _logger,
               null!); // TODO: Add dependency
   }
 
@@ -46,11 +46,11 @@ public class VerifyValidEmailAndInviteCode
   {
     var invitation = new Invitation(_email, _inviteCode, _subscriptionId);
 
-    _invitationRepository.Setup(r => r.FirstOrDefaultAsync(It.IsAny<InvitationByInviteCodeSpec>(), CancellationToken.None)).ReturnsAsync(invitation);
+    _invitationRepository.FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None).Returns(invitation);
 
     var result = await _newMemberService.VerifyValidEmailAndInviteCodeAsync(_email, _inviteCode);
 
-    _invitationRepository.Verify(r => r.FirstOrDefaultAsync(It.IsAny<InvitationByInviteCodeSpec>(), CancellationToken.None), Times.Once);
+    _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
     Assert.Equal(_validEmailAndInviteCodeString, result.Value);
   }
 
@@ -59,11 +59,11 @@ public class VerifyValidEmailAndInviteCode
   {
     var invitation = new Invitation("", _inviteCode, _subscriptionId);
 
-    _invitationRepository.Setup(r => r.FirstOrDefaultAsync(It.IsAny<InvitationByInviteCodeSpec>(), CancellationToken.None)).ReturnsAsync(invitation);
+    _invitationRepository.FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None).Returns(invitation);
 
     var result = await _newMemberService.VerifyValidEmailAndInviteCodeAsync(_email, _inviteCode);
 
-    _invitationRepository.Verify(r => r.FirstOrDefaultAsync(It.IsAny<InvitationByInviteCodeSpec>(), CancellationToken.None), Times.Once);
+    _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
     Assert.Equal(_invalidEmailString, result.Value);
   }
 
@@ -73,13 +73,13 @@ public class VerifyValidEmailAndInviteCode
 
 #pragma warning disable CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
 #pragma warning disable CS8600 // Converting null literal or possible null value to non-nullable type.
-    _ = _invitationRepository.Setup(r => r.FirstOrDefaultAsync(It.IsAny<InvitationByInviteCodeSpec>(), CancellationToken.None)).ReturnsAsync((Invitation)null);
+    _ = _invitationRepository.FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None).Returns((Invitation)null);
 #pragma warning restore CS8600 // Converting null literal or possible null value to non-nullable type.
 #pragma warning restore CS8620 // Argument cannot be used for parameter due to differences in the nullability of reference types.
 
     var result = await _newMemberService.VerifyValidEmailAndInviteCodeAsync(_email, _inviteCode);
 
-    _invitationRepository.Verify(r => r.FirstOrDefaultAsync(It.IsAny<InvitationByInviteCodeSpec>(), CancellationToken.None), Times.Once);
+    _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
     Assert.Equal(_invalidInviteCodeString, result.Value);
   }
 
@@ -90,11 +90,11 @@ public class VerifyValidEmailAndInviteCode
 
     _invitation.Deactivate();
 
-    _invitationRepository.Setup(r => r.FirstOrDefaultAsync(It.IsAny<InvitationByInviteCodeSpec>(), CancellationToken.None)).ReturnsAsync(_invitation);
+    _invitationRepository.FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None).Returns(_invitation);
 
     var result = await _newMemberService.VerifyValidEmailAndInviteCodeAsync(_email, _inviteCode);
 
-    _invitationRepository.Verify(r => r.FirstOrDefaultAsync(It.IsAny<InvitationByInviteCodeSpec>(), CancellationToken.None), Times.Once);
+    _invitationRepository.Received(1).FirstOrDefaultAsync(Arg.Any<InvitationByInviteCodeSpec>(), CancellationToken.None);
     Assert.Equal(_inactiveInviteString, result.Value);
   }
 }

--- a/tests/DevBetterWeb.UnitTests/DevBetterWeb.UnitTests.csproj
+++ b/tests/DevBetterWeb.UnitTests/DevBetterWeb.UnitTests.csproj
@@ -6,10 +6,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" />
-    <PackageReference Include="ILogger.Moq" />
     <PackageReference Include="Microsoft.Extensions.Identity.Core" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="Moq" />
+    <PackageReference Include="NSubstitute" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/DevBetterWeb.UnitTests/Infrastructure/Services/JsonParserServiceTests.cs
+++ b/tests/DevBetterWeb.UnitTests/Infrastructure/Services/JsonParserServiceTests.cs
@@ -44,7 +44,7 @@ public class JsonParserServiceTests
 
 		try
 		{
-			var actualResult = this._jsonParserService.Parse(invalidJson);
+			this._jsonParserService.Parse(invalidJson);
 		}
 		catch (JsonException ex)
 		{

--- a/tests/DevBetterWeb.UnitTests/NSubstituteLoggerExtensions.cs
+++ b/tests/DevBetterWeb.UnitTests/NSubstituteLoggerExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace DevBetterWeb.UnitTests;
+
+/// <summary>
+/// Extension methods to help verify calls to <see cref="ILogger"/>'s various extension methods
+/// that cannot be mocked/verified through normal means.
+/// </summary>
+internal static class NSubstituteLoggerExtensions
+{
+	/// <summary>
+	/// Use when you want to verify that <see cref="LoggerExtensions.LogInformation(Microsoft.Extensions.Logging.ILogger,Microsoft.Extensions.Logging.EventId,System.Exception?,string?,object?[])"/>
+	/// was called <paramref name="numberOfCalls"/> time(s) and with what message you expect.
+	/// </summary>
+	public static void ReceivedLogInformation(this ILogger mockedLogger, int numberOfCalls, string expectedMessage)
+	{
+		mockedLogger.Received(numberOfCalls).Log(LogLevel.Information, Arg.Any<EventId>(), expectedMessage);
+	}
+
+	/// <summary>
+	/// Use when you want to verify that <see cref="LoggerExtensions.LogError(Microsoft.Extensions.Logging.ILogger,Microsoft.Extensions.Logging.EventId,System.Exception?,string?,object?[])"/>
+	/// was called <paramref name="numberOfCalls"/> time(s) and with what excpetion and message you expect.
+	/// </summary>
+	public static void ReceivedLogError(this ILogger mockedLogger, int numberOfCalls, Exception expectedException, string expectedMessage)
+	{
+		mockedLogger.Received(numberOfCalls).Log(LogLevel.Error, Arg.Any<EventId>(), expectedException, expectedMessage);
+	}
+}

--- a/tests/DevBetterWeb.UnitTests/Web/Services/BookServiceTests/GetAllBooksAsync.cs
+++ b/tests/DevBetterWeb.UnitTests/Web/Services/BookServiceTests/GetAllBooksAsync.cs
@@ -1,24 +1,25 @@
 ﻿using System.Collections.Generic;
 using System.Threading;
 using Xunit;
-using Moq;
+using NSubstitute;
 using System.Threading.Tasks;
 using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Web.Services;
 using DevBetterWeb.Core.Interfaces;
 using DevBetterWeb.Core.Specs;
+using NSubstitute.ExceptionExtensions;
 
 namespace DevBetterWeb.UnitTests.Web.Services.FilteredBookDetailsTests;
 
 public class GetAllBooksAsync
 {
-	private readonly Mock<IRepository<Book>> _bookRepositoryMock;
+	private readonly IRepository<Book> _bookRepositoryMock;
 	private readonly BookService _bookService;
 
 	public GetAllBooksAsync()
 	{
-		_bookRepositoryMock = new Mock<IRepository<Book>>();
-		_bookService = new BookService(_bookRepositoryMock.Object);
+		_bookRepositoryMock = Substitute.For<IRepository<Book>>();
+		_bookService = new BookService(_bookRepositoryMock);
 	}
 
 	[Fact]
@@ -30,13 +31,13 @@ public class GetAllBooksAsync
 						new Book { Title = "Book2", Author = "Author2" }
 		};
 
-		_bookRepositoryMock.Setup(repo => repo.ListAsync(It.IsAny<BooksOrderedByReadsSpec>(), CancellationToken.None)).ReturnsAsync(expectedBooks);
+		_bookRepositoryMock.ListAsync(Arg.Any<BooksOrderedByReadsSpec>(), CancellationToken.None).Returns(expectedBooks);
 
 		// Act
 		var actualBooksViewModel = await _bookService.GetAllBooksAsync();
 
 		// Assert
-		_bookRepositoryMock.Verify(repo => repo.ListAsync(It.IsAny<BooksOrderedByReadsSpec>(), CancellationToken.None), Times.Once);
+		await _bookRepositoryMock.Received(1).ListAsync(Arg.Any<BooksOrderedByReadsSpec>(), CancellationToken.None);
 
 		Assert.Equal(expectedBooks.Count, actualBooksViewModel.Count);
 		foreach (var expectedBook in expectedBooks)
@@ -49,13 +50,13 @@ public class GetAllBooksAsync
 	public async Task ReturnsEmptyListGivenNoBooks()
 	{
 		// Arrange
-		_bookRepositoryMock.Setup(repo => repo.ListAsync(It.IsAny<BooksOrderedByReadsSpec>(), CancellationToken.None)).ReturnsAsync(new List<Book>());
+		_bookRepositoryMock.ListAsync(Arg.Any<BooksOrderedByReadsSpec>(), CancellationToken.None).Returns(new List<Book>());
 
 		// Act
 		var actualBooksViewModel = await _bookService.GetAllBooksAsync();
 
 		// Assert
-		_bookRepositoryMock.Verify(repo => repo.ListAsync(It.IsAny<BooksOrderedByReadsSpec>(), CancellationToken.None), Times.Once);
+		await _bookRepositoryMock.Received(1).ListAsync(Arg.Any<BooksOrderedByReadsSpec>(), CancellationToken.None);
 
 		Assert.Empty(actualBooksViewModel);
 	}
@@ -97,13 +98,13 @@ public class GetAllBooksAsync
 		};
 
 		var expectedBooks = new List<Book> { book1, book2, book3 };
-		_bookRepositoryMock.Setup(repo => repo.ListAsync(It.IsAny<BooksOrderedByReadsSpec>(), CancellationToken.None)).ReturnsAsync(expectedBooks);
+		_bookRepositoryMock.ListAsync(Arg.Any<BooksOrderedByReadsSpec>(), CancellationToken.None).Returns(expectedBooks);
 
 		// Act
 		var actualBooksViewModel = await _bookService.GetAllBooksAsync();
 
 		// Assert
-		_bookRepositoryMock.Verify(repo => repo.ListAsync(It.IsAny<BooksOrderedByReadsSpec>(), CancellationToken.None), Times.Once);
+		await _bookRepositoryMock.Received(1).ListAsync(Arg.Any<BooksOrderedByReadsSpec>(), CancellationToken.None);
 
 		Assert.Equal(expectedBooks.Count, actualBooksViewModel.Count);
 		Assert.Equal(book2.Title, actualBooksViewModel[0].Title); // Book2 has higher ReadsCount
@@ -115,7 +116,7 @@ public class GetAllBooksAsync
 	public async Task ThrowsExceptionWhenRepositoryFails()
 	{
 		// Arrange
-		_bookRepositoryMock.Setup(repo => repo.ListAsync(It.IsAny<BooksOrderedByReadsSpec>(), CancellationToken.None)).ThrowsAsync(new System.Exception());
+		_bookRepositoryMock.ListAsync(Arg.Any<BooksOrderedByReadsSpec>(), CancellationToken.None).ThrowsAsync(new System.Exception());
 
 		// Act & Assert
 		await Assert.ThrowsAsync<System.Exception>(() => _bookService.GetAllBooksAsync());

--- a/tests/DevBetterWeb.UnitTests/Web/Services/FilteredBookDetailsTests/GetBookDetailsAsync.cs
+++ b/tests/DevBetterWeb.UnitTests/Web/Services/FilteredBookDetailsTests/GetBookDetailsAsync.cs
@@ -2,7 +2,7 @@
 using System.Threading;
 using DevBetterWeb.Web.Interfaces;
 using Xunit;
-using Moq;
+using NSubstitute;
 using System.Threading.Tasks;
 using DevBetterWeb.Core.Entities;
 using DevBetterWeb.Infrastructure.Interfaces;
@@ -13,15 +13,15 @@ namespace DevBetterWeb.UnitTests.Web.Services.FilteredBookDetailsTests;
 
 public class GetBookDetailsAsync
 {
-	private readonly Mock<INonCurrentMembersService> _nonCurrentMembersServiceMock;
-	private readonly Mock<IBookService> _bookServiceMock;
+	private readonly INonCurrentMembersService _nonCurrentMembersServiceMock;
+	private readonly IBookService _bookServiceMock;
 	private readonly FilteredBookDetailsService _filteredBookDetailsService;
 
 	public GetBookDetailsAsync()
 	{
-		_nonCurrentMembersServiceMock = new Mock<INonCurrentMembersService>();
-		_bookServiceMock = new Mock<IBookService>();
-		_filteredBookDetailsService = new FilteredBookDetailsService(_nonCurrentMembersServiceMock.Object, _bookServiceMock.Object);
+		_nonCurrentMembersServiceMock = Substitute.For<INonCurrentMembersService>();
+		_bookServiceMock = Substitute.For<IBookService>();
+		_filteredBookDetailsService = new FilteredBookDetailsService(_nonCurrentMembersServiceMock, _bookServiceMock);
 	}
 
 	[Fact]
@@ -29,7 +29,7 @@ public class GetBookDetailsAsync
 	{
 		// Arrange
 		var bookId = "1";
-		_bookServiceMock.Setup(s => s.GetBookByIdAsync(int.Parse(bookId))).ReturnsAsync((BookDetailsViewModel?)null);
+		_bookServiceMock.GetBookByIdAsync(int.Parse(bookId)).Returns((BookDetailsViewModel?)null);
 
 		// Act
 		var result = await _filteredBookDetailsService.GetBookDetailsAsync(bookId);
@@ -44,7 +44,7 @@ public class GetBookDetailsAsync
 		// Arrange
 		var bookId = "1";
 		var bookDetails = new BookDetailsViewModel();
-		_bookServiceMock.Setup(s => s.GetBookByIdAsync(int.Parse(bookId))).ReturnsAsync(bookDetails);
+		_bookServiceMock.GetBookByIdAsync(int.Parse(bookId)).Returns(bookDetails);
 
 		// Act
 		var result = await _filteredBookDetailsService.GetBookDetailsAsync(bookId);
@@ -67,9 +67,9 @@ public class GetBookDetailsAsync
 		{
 			MembersWhoHaveRead = new List<Member> { new Member { Id = 1 } }
 		};
-		_bookServiceMock.Setup(s => s.GetBookByIdAsync(int.Parse(bookId))).ReturnsAsync(bookDetails);
-		_nonCurrentMembersServiceMock.Setup(s => s.GetUsersIdsWithoutRolesAsync()).ReturnsAsync(new List<string> { "2", "3" });
-		_nonCurrentMembersServiceMock.Setup(s => s.GetNonCurrentMembersAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<int> { 2, 3 });
+		_bookServiceMock.GetBookByIdAsync(int.Parse(bookId)).Returns(bookDetails);
+		_nonCurrentMembersServiceMock.GetUsersIdsWithoutRolesAsync().Returns(new List<string> { "2", "3" });
+		_nonCurrentMembersServiceMock.GetNonCurrentMembersAsync(Arg.Any<List<string>>(), Arg.Any<CancellationToken>()).Returns(new List<int> { 2, 3 });
 
 		// Act
 		var result = await _filteredBookDetailsService.GetBookDetailsAsync(bookId);

--- a/tests/DevBetterWeb.UnitTests/Web/Services/FilteredBookDetailsTests/RemoveNonCurrentMembersFromBookDetailsAsync.cs
+++ b/tests/DevBetterWeb.UnitTests/Web/Services/FilteredBookDetailsTests/RemoveNonCurrentMembersFromBookDetailsAsync.cs
@@ -7,21 +7,21 @@ using DevBetterWeb.Infrastructure.Interfaces;
 using DevBetterWeb.Web.Interfaces;
 using DevBetterWeb.Web.Pages.Leaderboard;
 using DevBetterWeb.Web.Services;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.UnitTests.Web.Services.FilteredBookDetailsTests;
 
 public class RemoveNonCurrentMembersFromBookDetailsAsync
 {
-	private readonly Mock<INonCurrentMembersService> _mockNonCurrentMembersService;
+	private readonly INonCurrentMembersService _mockNonCurrentMembersService;
 	private readonly FilteredBookDetailsService _filteredBookDetailsService;
 
 	public RemoveNonCurrentMembersFromBookDetailsAsync()
 	{
-		_mockNonCurrentMembersService = new Mock<INonCurrentMembersService>();
-		var bookService = new Mock<IBookService>();
-		_filteredBookDetailsService = new FilteredBookDetailsService(_mockNonCurrentMembersService.Object, bookService.Object);
+		_mockNonCurrentMembersService = Substitute.For<INonCurrentMembersService>();
+		var bookService = Substitute.For<IBookService>();
+		_filteredBookDetailsService = new FilteredBookDetailsService(_mockNonCurrentMembersService, bookService);
 	}
 
 	[Fact]
@@ -32,11 +32,11 @@ public class RemoveNonCurrentMembersFromBookDetailsAsync
 		{
 			MembersWhoHaveRead = new List<Member> { new Member { Id = 1 }, new Member { Id = 2 }, new Member { Id = 3 } }
 		};
-		_mockNonCurrentMembersService.Setup(s => s.GetUsersIdsWithoutRolesAsync())
-			.ReturnsAsync(new List<string> { "1", "2" });
+		_mockNonCurrentMembersService.GetUsersIdsWithoutRolesAsync()
+			.Returns(new List<string> { "1", "2" });
 		_mockNonCurrentMembersService
-			.Setup(s => s.GetNonCurrentMembersAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new List<int> { 1, 2 });
+			.GetNonCurrentMembersAsync(Arg.Any<List<string>>(), Arg.Any<CancellationToken>())
+			.Returns(new List<int> { 1, 2 });
 
 		// Act
 		var result = await _filteredBookDetailsService.RemoveNonCurrentMembersFromBookDetailsAsync(bookDetailsViewModel);
@@ -54,11 +54,11 @@ public class RemoveNonCurrentMembersFromBookDetailsAsync
 		{
 			MembersWhoHaveRead = new List<Member> { new Member { Id = 1 }, new Member { Id = 2 }, new Member { Id = 3 } }
 		};
-		_mockNonCurrentMembersService.Setup(s => s.GetUsersIdsWithoutRolesAsync())
-			.ReturnsAsync(new List<string> { "4", "5" });
+		_mockNonCurrentMembersService.GetUsersIdsWithoutRolesAsync()
+			.Returns(new List<string> { "4", "5" });
 		_mockNonCurrentMembersService
-			.Setup(s => s.GetNonCurrentMembersAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new List<int> { 4, 5 });
+			.GetNonCurrentMembersAsync(Arg.Any<List<string>>(), Arg.Any<CancellationToken>())
+			.Returns(new List<int> { 4, 5 });
 
 		// Act
 		var result = await _filteredBookDetailsService.RemoveNonCurrentMembersFromBookDetailsAsync(bookDetailsViewModel);
@@ -75,10 +75,10 @@ public class RemoveNonCurrentMembersFromBookDetailsAsync
 		{
 			MembersWhoHaveRead = new List<Member> { new Member { Id = 1 }, new Member { Id = 2 }, new Member { Id = 3 } }
 		};
-		_mockNonCurrentMembersService.Setup(s => s.GetUsersIdsWithoutRolesAsync()).ReturnsAsync(new List<string> { });
+		_mockNonCurrentMembersService.GetUsersIdsWithoutRolesAsync().Returns(new List<string> { });
 		_mockNonCurrentMembersService
-			.Setup(s => s.GetNonCurrentMembersAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(new List<int> { });
+			.GetNonCurrentMembersAsync(Arg.Any<List<string>>(), Arg.Any<CancellationToken>())
+			.Returns(new List<int> { });
 
 		// Act
 		var result = await _filteredBookDetailsService.RemoveNonCurrentMembersFromBookDetailsAsync(bookDetailsViewModel);
@@ -92,8 +92,8 @@ public class RemoveNonCurrentMembersFromBookDetailsAsync
 	{
 		// Arrange
 		var bookDetailsViewModel = new BookDetailsViewModel { MembersWhoHaveRead = new List<Member> { } };
-		_mockNonCurrentMembersService.Setup(s => s.GetUsersIdsWithoutRolesAsync()).ReturnsAsync(new List<string> { "1", "2" });
-		_mockNonCurrentMembersService.Setup(s => s.GetNonCurrentMembersAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<int> { 1, 2 });
+		_mockNonCurrentMembersService.GetUsersIdsWithoutRolesAsync().Returns(new List<string> { "1", "2" });
+		_mockNonCurrentMembersService.GetNonCurrentMembersAsync(Arg.Any<List<string>>(), Arg.Any<CancellationToken>()).Returns(new List<int> { 1, 2 });
 
 		// Act
 		var result = await _filteredBookDetailsService.RemoveNonCurrentMembersFromBookDetailsAsync(bookDetailsViewModel);
@@ -110,8 +110,8 @@ public class RemoveNonCurrentMembersFromBookDetailsAsync
 		{
 			MembersWhoHaveRead = new List<Member> { new Member { Id = 1 }, new Member { Id = 2 }, new Member { Id = 3 } }
 		};
-		_mockNonCurrentMembersService.Setup(s => s.GetUsersIdsWithoutRolesAsync()).ReturnsAsync(new List<string> { "1", "2", "3" });
-		_mockNonCurrentMembersService.Setup(s => s.GetNonCurrentMembersAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>())).ReturnsAsync(new List<int> { 1, 2, 3 });
+		_mockNonCurrentMembersService.GetUsersIdsWithoutRolesAsync().Returns(new List<string> { "1", "2", "3" });
+		_mockNonCurrentMembersService.GetNonCurrentMembersAsync(Arg.Any<List<string>>(), Arg.Any<CancellationToken>()).Returns(new List<int> { 1, 2, 3 });
 
 		// Act
 		var result = await _filteredBookDetailsService.RemoveNonCurrentMembersFromBookDetailsAsync(bookDetailsViewModel);
@@ -120,4 +120,3 @@ public class RemoveNonCurrentMembersFromBookDetailsAsync
 		Assert.Empty(result.MembersWhoHaveRead);
 	}
 }
-

--- a/tests/DevBetterWeb.UnitTests/Web/Services/FilteredLeaderboardTests/RemoveNonCurrentMembersFromLeaderBoardAsync.cs
+++ b/tests/DevBetterWeb.UnitTests/Web/Services/FilteredLeaderboardTests/RemoveNonCurrentMembersFromLeaderBoardAsync.cs
@@ -6,20 +6,20 @@ using DevBetterWeb.Infrastructure.Interfaces;
 using DevBetterWeb.Web.Interfaces;
 using DevBetterWeb.Web.Models;
 using DevBetterWeb.Web.Services;
-using Moq;
+using NSubstitute;
 using Xunit;
 
 namespace DevBetterWeb.UnitTests.Web.Services.FilteredLeaderboardTests;
 
 public class FilteredLeaderboardServiceTests
 {
-	private readonly Mock<INonCurrentMembersService> _nonCurrentMembersServiceMock;
-	private readonly Mock<IMemberService> _memberServiceMock;
+	private readonly INonCurrentMembersService _nonCurrentMembersServiceMock;
+	private readonly IMemberService _memberServiceMock;
 
 	public FilteredLeaderboardServiceTests()
 	{
-		_nonCurrentMembersServiceMock = new Mock<INonCurrentMembersService>();
-		_memberServiceMock = new Mock<IMemberService>();
+		_nonCurrentMembersServiceMock = Substitute.For<INonCurrentMembersService>();
+		_memberServiceMock = Substitute.For<IMemberService>();
 	}
 
 	[Fact]
@@ -30,15 +30,15 @@ public class FilteredLeaderboardServiceTests
 		List<string> nonUsersId = new List<string> { "3" };
 		List<int> nonMembersId = new List<int> { 3 };
 
-		_nonCurrentMembersServiceMock.Setup(service => service.GetUsersIdsWithoutRolesAsync())
-				.ReturnsAsync(nonUsersId);
-		_nonCurrentMembersServiceMock.Setup(service => service.GetNonCurrentMembersAsync(nonUsersId, CancellationToken.None))
-				.ReturnsAsync(nonMembersId);
+		_nonCurrentMembersServiceMock.GetUsersIdsWithoutRolesAsync()
+				.Returns(nonUsersId);
+		_nonCurrentMembersServiceMock.GetNonCurrentMembersAsync(nonUsersId, CancellationToken.None)
+				.Returns(nonMembersId);
 
-		_memberServiceMock.Setup(service => service.GetActiveAlumniMembersAsync())
-				.ReturnsAsync(new List<Member>());
+		_memberServiceMock.GetActiveAlumniMembersAsync()
+				.Returns(new List<Member>());
 
-		var service = new FilteredLeaderboardService(_nonCurrentMembersServiceMock.Object, _memberServiceMock.Object);
+		var service = new FilteredLeaderboardService(_nonCurrentMembersServiceMock, _memberServiceMock);
 
 		// Act
 		var filteredBookCategories = await service.RemoveNonCurrentMembersFromLeaderBoardAsync(bookCategories);

--- a/tests/DevBetterWeb.UnitTests/Web/Services/RankAndOrderServiceTests/OrderByRankForMembersAndBooks.cs
+++ b/tests/DevBetterWeb.UnitTests/Web/Services/RankAndOrderServiceTests/OrderByRankForMembersAndBooks.cs
@@ -4,21 +4,21 @@ using DevBetterWeb.Web.Interfaces;
 using DevBetterWeb.Web.Models;
 using DevBetterWeb.Web.Services;
 using Xunit;
-using Moq;
+using NSubstitute;
 using System;
 
 namespace DevBetterWeb.UnitTests.Web.Services.RankAndOrderServiceTests;
 
 public class OrderByRankForMembersAndBooks
 {
-	private readonly Mock<IRankingService> _mockRankingService;
+	private readonly IRankingService _mockRankingService;
 	private readonly RankAndOrderService _rankAndOrderService;
 
 	public OrderByRankForMembersAndBooks()
 	{
-		_mockRankingService = new Mock<IRankingService>();
-		var mockMemberService = new Mock<IMemberService>();
-		_rankAndOrderService = new RankAndOrderService(_mockRankingService.Object, mockMemberService.Object);
+		_mockRankingService = Substitute.For<IRankingService>();
+		var mockMemberService = Substitute.For<IMemberService>();
+		_rankAndOrderService = new RankAndOrderService(_mockRankingService, mockMemberService);
 	}
 
 	private List<BookCategoryDto> GetTestBookCategories()
@@ -55,8 +55,8 @@ public class OrderByRankForMembersAndBooks
 		_rankAndOrderService.OrderByRankForMembersAndBooks(bookCategories);
 
 		// Assert
-		_mockRankingService.Verify(rs => rs.OrderMembersByRank(It.IsAny<List<MemberForBookDto>>()), Times.Exactly(bookCategories.Count * 2));
-		_mockRankingService.Verify(rs => rs.OrderBooksByRank(It.IsAny<List<BookDto>>()), Times.Exactly(bookCategories.Count));
+		_mockRankingService.Received(bookCategories.Count * 2).OrderMembersByRank(Arg.Any<List<MemberForBookDto>>());
+		_mockRankingService.Received(bookCategories.Count).OrderBooksByRank(Arg.Any<List<BookDto>>());
 	}
 
 	[Fact]
@@ -69,8 +69,8 @@ public class OrderByRankForMembersAndBooks
 		_rankAndOrderService.OrderByRankForMembersAndBooks(bookCategories);
 
 		// Assert
-		_mockRankingService.Verify(rs => rs.OrderMembersByRank(It.IsAny<List<MemberForBookDto>>()), Times.Never());
-		_mockRankingService.Verify(rs => rs.OrderBooksByRank(It.IsAny<List<BookDto>>()), Times.Never());
+		_mockRankingService.DidNotReceive().OrderMembersByRank(Arg.Any<List<MemberForBookDto>>());
+		_mockRankingService.DidNotReceive().OrderBooksByRank(Arg.Any<List<BookDto>>());
 	}
 
 	[Fact]

--- a/tests/DevBetterWeb.UnitTests/Web/Services/RankAndOrderServiceTests/UpdateMembersReadRank.cs
+++ b/tests/DevBetterWeb.UnitTests/Web/Services/RankAndOrderServiceTests/UpdateMembersReadRank.cs
@@ -4,7 +4,7 @@ using DevBetterWeb.Web.Interfaces;
 using DevBetterWeb.Web.Models;
 using DevBetterWeb.Web.Services;
 using Xunit;
-using Moq;
+using NSubstitute;
 using System.Linq;
 using System;
 
@@ -12,14 +12,14 @@ namespace DevBetterWeb.UnitTests.Web.Services.RankAndOrderServiceTests;
 
 public class UpdateMembersReadRank
 {
-	private readonly Mock<IRankingService> _mockRankingService;
+	private readonly IRankingService _mockRankingService;
 	private readonly RankAndOrderService _rankAndOrderService;
 
 	public UpdateMembersReadRank()
 	{
-		_mockRankingService = new Mock<IRankingService>();
-		var mockMemberService = new Mock<IMemberService>();
-		_rankAndOrderService = new RankAndOrderService(_mockRankingService.Object, mockMemberService.Object);
+		_mockRankingService = Substitute.For<IRankingService>();
+		var mockMemberService = Substitute.For<IMemberService>();
+		_rankAndOrderService = new RankAndOrderService(_mockRankingService, mockMemberService);
 	}
 
 	private List<BookCategoryDto> GetTestBookCategories()
@@ -58,8 +58,8 @@ public class UpdateMembersReadRank
 		// Assert
 		foreach (var category in bookCategories)
 		{
-			_mockRankingService.Verify(rs => rs.CalculateMemberRank(category.Members), Times.AtLeastOnce());
-			_mockRankingService.Verify(rs => rs.CalculateMemberRank(category.Alumnus), Times.AtLeastOnce());
+			_mockRankingService.Received().CalculateMemberRank(category.Members);
+			_mockRankingService.Received().CalculateMemberRank(category.Alumnus);
 		}
 	}
 
@@ -73,7 +73,7 @@ public class UpdateMembersReadRank
 		_rankAndOrderService.UpdateMembersReadRank(bookCategories);
 
 		// Assert
-		_mockRankingService.Verify(rs => rs.CalculateMemberRank(It.IsAny<List<MemberForBookDto>>()), Times.Never());
+		_mockRankingService.DidNotReceive().CalculateMemberRank(Arg.Any<List<MemberForBookDto>>());
 	}
 
 
@@ -88,7 +88,7 @@ public class UpdateMembersReadRank
 		_rankAndOrderService.UpdateMembersReadRank(bookCategories);
 
 		// Assert
-		_mockRankingService.Verify(rs => rs.CalculateMemberRank(It.IsAny<List<MemberForBookDto>>()), Times.Exactly(bookCategories.Count * 2));
+		_mockRankingService.Received(bookCategories.Count * 2).CalculateMemberRank(Arg.Any<List<MemberForBookDto>>());
 	}
 
 	[Fact]
@@ -157,6 +157,6 @@ public class UpdateMembersReadRank
 		_rankAndOrderService.UpdateMembersReadRank(bookCategories);
 
 		// Assert
-		_mockRankingService.Verify(rs => rs.CalculateMemberRank(It.IsAny<List<MemberForBookDto>>()), Times.Never());
+		_mockRankingService.DidNotReceive().CalculateMemberRank(Arg.Any<List<MemberForBookDto>>());
 	}
 }

--- a/tests/DevBetterWeb.UnitTests/Web/Services/RankAndOrderServiceTests/UpdateRanksAndReadBooksCountForMemberAsync.cs
+++ b/tests/DevBetterWeb.UnitTests/Web/Services/RankAndOrderServiceTests/UpdateRanksAndReadBooksCountForMemberAsync.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using DevBetterWeb.Web.Models;
 using DevBetterWeb.Web.Services;
 using Xunit;
-using Moq;
+using NSubstitute;
 using System.Linq;
 using DevBetterWeb.Core;
 using DevBetterWeb.Core.Entities;
@@ -13,14 +13,14 @@ namespace DevBetterWeb.UnitTests.Web.Services.RankAndOrderServiceTests;
 
 public class UpdateRanksAndReadBooksCountForMemberAsync
 {
-	private readonly Mock<IMemberService> _mockMemberService;
+	private readonly IMemberService _mockMemberService;
 	private readonly RankAndOrderService _rankAndOrderService;
 
 	public UpdateRanksAndReadBooksCountForMemberAsync()
 	{
-		var mockRankingService = new Mock<IRankingService>();
-		_mockMemberService = new Mock<IMemberService>();
-		_rankAndOrderService = new RankAndOrderService(mockRankingService.Object, _mockMemberService.Object);
+		var mockRankingService = Substitute.For<IRankingService>();
+		_mockMemberService = Substitute.For<IMemberService>();
+		_rankAndOrderService = new RankAndOrderService(mockRankingService, _mockMemberService);
 	}
 
 	[Fact]
@@ -53,7 +53,7 @@ public class UpdateRanksAndReadBooksCountForMemberAsync
 								}
 						}
 				};
-		_mockMemberService.Setup(x => x.GetActiveAlumniMembersAsync()).ReturnsAsync(new List<Member> { });
+		_mockMemberService.GetActiveAlumniMembersAsync().Returns(new List<Member> { });
 
 		// Act
 		await _rankAndOrderService.UpdateRanksAndReadBooksCountForMemberAsync(bookCategories);
@@ -93,7 +93,7 @@ public class UpdateRanksAndReadBooksCountForMemberAsync
 								}
 						}
 				};
-		_mockMemberService.Setup(x => x.GetActiveAlumniMembersAsync()).ReturnsAsync(new List<Member> { new Member { Id = 1 }, new Member { Id = 2 } });
+		_mockMemberService.GetActiveAlumniMembersAsync().Returns(new List<Member> { new Member { Id = 1 }, new Member { Id = 2 } });
 
 		// Act
 		await _rankAndOrderService.UpdateRanksAndReadBooksCountForMemberAsync(bookCategories);
@@ -136,7 +136,7 @@ public class UpdateRanksAndReadBooksCountForMemberAsync
 				}
 			}
 		};
-		_mockMemberService.Setup(x => x.GetActiveAlumniMembersAsync()).ReturnsAsync(new List<Member> { new Member { Id = 5 }, new Member { Id = 6 } });
+		_mockMemberService.GetActiveAlumniMembersAsync().Returns(new List<Member> { new Member { Id = 5 }, new Member { Id = 6 } });
 
 		// Act
 		await _rankAndOrderService.UpdateRanksAndReadBooksCountForMemberAsync(bookCategories);

--- a/tests/DevBetterWeb.UnitTests/Web/Services/VideoDetailsServiceTests.cs
+++ b/tests/DevBetterWeb.UnitTests/Web/Services/VideoDetailsServiceTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using FluentAssertions;
 using Flurl.Http.Testing;
-using Moq;
+using NSubstitute;
 using Xunit;
 using DevBetterWeb.Web.Interfaces;
 using DevBetterWeb.Web.Services;
@@ -17,9 +17,9 @@ public class VideoDetailsServiceTests
 	public async void GetTranscript_Returns_Empty_String_When_No_TextTracks()
 	{
 		List<TextTrack> textTracks = new();
-		var vttServiceMock = new Mock<IWebVTTParsingService>();
-		vttServiceMock.Setup(x => x.Parse(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>())).Returns("test");
-		var videoDetailsService = new VideoDetailsService(null!, null!, null!, null!, vttServiceMock.Object);
+		var vttServiceMock = Substitute.For<IWebVTTParsingService>();
+		vttServiceMock.Parse(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>()).Returns("test");
+		var videoDetailsService = new VideoDetailsService(null!, null!, null!, null!, vttServiceMock);
 
 		var result = await videoDetailsService.GetTranscriptAsync(textTracks, "https://it-does-not-matter-for-this-test.com");
 
@@ -31,9 +31,9 @@ public class VideoDetailsServiceTests
 	{
 		List<TextTrack> textTracks = new() { new TextTrack { Link = "I am most definitely not a valid url" } };
 		_httpTest.RespondWith("Me no findy", 404);
-		var vttServiceMock = new Mock<IWebVTTParsingService>();
-		vttServiceMock.Setup(x => x.Parse(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<int>())).Returns("test");
-		var videoDetailsService = new VideoDetailsService(null!, null!, null!, null!, vttServiceMock.Object);
+		var vttServiceMock = Substitute.For<IWebVTTParsingService>();
+		vttServiceMock.Parse(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<int>()).Returns("test");
+		var videoDetailsService = new VideoDetailsService(null!, null!, null!, null!, vttServiceMock);
 
 		var result = await videoDetailsService.GetTranscriptAsync(textTracks, "https://it-does-not-matter-for-this-test.com");
 


### PR DESCRIPTION
- Completes #1141 
- Removes `Moq` NuGet package and replaces it with `NSubstitute`
- Removes `ILogger.Moq` NuGet package
  - This was replaced with `NSubstituteLoggerExtensions` (custom implementation), which is open to be expanded, but was done bare-minimum style to make the tests continue to pass with verifying `ILogger` calls.
- Removed a stray floating `</a>` from a view