### PR TITLE
Ensure we only fail the build when vulnerabilities exist in top level NuGet packages

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+<PropertyGroup>
+  <NuGetAuditMode>direct</NuGetAuditMode>
+</PropertyGroup>
+</Project>


### PR DESCRIPTION
Note that this does not update NuGet packages.