### PR TITLE
Admin Manage Subscriptions page with pause, resume, and cancel actions

### DIFF
--- a/src/DevBetterWeb.Infrastructure/InfrastructureServiceCollectionExtensions.cs
+++ b/src/DevBetterWeb.Infrastructure/InfrastructureServiceCollectionExtensions.cs
@@ -8,6 +8,7 @@ using DevBetterWeb.Infrastructure.InvoiceHandler.StripeInvoiceHandler;
 using DevBetterWeb.Infrastructure.IssuingHandler.StripeIssuingHandler;
 using DevBetterWeb.Infrastructure.Logging;
 using DevBetterWeb.Infrastructure.Services;
+using DevBetterWeb.Infrastructure.SubscriptionHandler.StripeSubscriptionHandler;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Stripe;
@@ -74,6 +75,7 @@ public static class InfrastructureServiceCollectionExtensions
 		services.AddTransient<IIssuingHandlerCardListService, StripeIssuingHandlerCardListService>();
 		services.AddTransient<IIssuingHandlerTransactionListService, StripeIssuingHandlerTransactionListService>();
 		services.AddTransient<IInvoiceHandlerListService, StripeInvoiceHandlerListService>();
+		services.AddTransient<ISubscriptionHandlerService, StripeSubscriptionHandlerService>();
 
 		// Vimeo
 		services.RegisterVimeoServicesDependencies(vimeoToken);

--- a/src/DevBetterWeb.Infrastructure/Interfaces/ISubscriptionHandlerService.cs
+++ b/src/DevBetterWeb.Infrastructure/Interfaces/ISubscriptionHandlerService.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Stripe;
+
+namespace DevBetterWeb.Infrastructure.Interfaces;
+
+public interface ISubscriptionHandlerService
+{
+	Task<List<Subscription>> ListBillableAsync(CancellationToken cancellationToken = default);
+	Task<Subscription> PauseAsync(string subscriptionId, CancellationToken cancellationToken = default);
+	Task<Subscription> ResumeAsync(string subscriptionId, CancellationToken cancellationToken = default);
+	Task<Subscription> CancelAtPeriodEndAsync(string subscriptionId, CancellationToken cancellationToken = default);
+	Task<Subscription> CancelImmediatelyAsync(string subscriptionId, CancellationToken cancellationToken = default);
+}

--- a/src/DevBetterWeb.Infrastructure/SubscriptionHandler/StripeSubscriptionHandler/StripeSubscriptionHandlerService.cs
+++ b/src/DevBetterWeb.Infrastructure/SubscriptionHandler/StripeSubscriptionHandler/StripeSubscriptionHandlerService.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using DevBetterWeb.Infrastructure.Interfaces;
+using Stripe;
+
+namespace DevBetterWeb.Infrastructure.SubscriptionHandler.StripeSubscriptionHandler;
+
+public class StripeSubscriptionHandlerService : ISubscriptionHandlerService
+{
+	private static readonly HashSet<string> _billableStatuses =
+		new() { "active", "past_due", "trialing", "unpaid" };
+
+	private readonly SubscriptionService _subscriptionService;
+
+	public StripeSubscriptionHandlerService(SubscriptionService subscriptionService)
+	{
+		_subscriptionService = subscriptionService;
+	}
+
+	public async Task<List<Subscription>> ListBillableAsync(CancellationToken cancellationToken = default)
+	{
+		var options = new SubscriptionListOptions { Status = "all", Limit = 100 };
+		options.AddExpand("data.customer");
+
+		var subscriptions = new List<Subscription>();
+		StripeList<Subscription> page;
+		do
+		{
+			page = await _subscriptionService.ListAsync(options, cancellationToken: cancellationToken);
+			subscriptions.AddRange(page.Data);
+			if (page.Data.Count > 0)
+			{
+				options.StartingAfter = page.Data[^1].Id;
+			}
+		} while (page.HasMore);
+
+		return subscriptions.Where(s => _billableStatuses.Contains(s.Status)).ToList();
+	}
+
+	public Task<Subscription> PauseAsync(string subscriptionId, CancellationToken cancellationToken = default)
+		=> throw new NotImplementedException();
+
+	public Task<Subscription> ResumeAsync(string subscriptionId, CancellationToken cancellationToken = default)
+		=> throw new NotImplementedException();
+
+	public Task<Subscription> CancelAtPeriodEndAsync(string subscriptionId, CancellationToken cancellationToken = default)
+		=> throw new NotImplementedException();
+
+	public Task<Subscription> CancelImmediatelyAsync(string subscriptionId, CancellationToken cancellationToken = default)
+		=> throw new NotImplementedException();
+}

--- a/src/DevBetterWeb.Infrastructure/SubscriptionHandler/StripeSubscriptionHandler/StripeSubscriptionHandlerService.cs
+++ b/src/DevBetterWeb.Infrastructure/SubscriptionHandler/StripeSubscriptionHandler/StripeSubscriptionHandlerService.cs
@@ -62,8 +62,17 @@ public class StripeSubscriptionHandlerService : ISubscriptionHandlerService
 	}
 
 	public Task<Subscription> CancelAtPeriodEndAsync(string subscriptionId, CancellationToken cancellationToken = default)
-		=> throw new NotImplementedException();
+	{
+		var options = new SubscriptionUpdateOptions
+		{
+			CancelAtPeriodEnd = true,
+		};
+
+		return _subscriptionService.UpdateAsync(subscriptionId, options, cancellationToken: cancellationToken);
+	}
 
 	public Task<Subscription> CancelImmediatelyAsync(string subscriptionId, CancellationToken cancellationToken = default)
-		=> throw new NotImplementedException();
+	{
+		return _subscriptionService.CancelAsync(subscriptionId, null, cancellationToken: cancellationToken);
+	}
 }

--- a/src/DevBetterWeb.Infrastructure/SubscriptionHandler/StripeSubscriptionHandler/StripeSubscriptionHandlerService.cs
+++ b/src/DevBetterWeb.Infrastructure/SubscriptionHandler/StripeSubscriptionHandler/StripeSubscriptionHandlerService.cs
@@ -35,7 +35,7 @@ public class StripeSubscriptionHandlerService : ISubscriptionHandlerService
 			{
 				options.StartingAfter = page.Data[^1].Id;
 			}
-		} while (page.HasMore);
+		} while (page.HasMore && page.Data.Count > 0);
 
 		return subscriptions.Where(s => _billableStatuses.Contains(s.Status)).ToList();
 	}

--- a/src/DevBetterWeb.Infrastructure/SubscriptionHandler/StripeSubscriptionHandler/StripeSubscriptionHandlerService.cs
+++ b/src/DevBetterWeb.Infrastructure/SubscriptionHandler/StripeSubscriptionHandler/StripeSubscriptionHandlerService.cs
@@ -41,10 +41,25 @@ public class StripeSubscriptionHandlerService : ISubscriptionHandlerService
 	}
 
 	public Task<Subscription> PauseAsync(string subscriptionId, CancellationToken cancellationToken = default)
-		=> throw new NotImplementedException();
+	{
+		var options = new SubscriptionUpdateOptions
+		{
+			PauseCollection = new SubscriptionPauseCollectionOptions
+			{
+				Behavior = "void",
+			},
+		};
+
+		return _subscriptionService.UpdateAsync(subscriptionId, options, cancellationToken: cancellationToken);
+	}
 
 	public Task<Subscription> ResumeAsync(string subscriptionId, CancellationToken cancellationToken = default)
-		=> throw new NotImplementedException();
+	{
+		var options = new SubscriptionUpdateOptions();
+		options.AddExtraParam("pause_collection", "");
+
+		return _subscriptionService.UpdateAsync(subscriptionId, options, cancellationToken: cancellationToken);
+	}
 
 	public Task<Subscription> CancelAtPeriodEndAsync(string subscriptionId, CancellationToken cancellationToken = default)
 		=> throw new NotImplementedException();

--- a/src/DevBetterWeb.Web/Endpoints/StripeWebhookEndpoints/CustomerSubscriptionUpdatedWebHook.cs
+++ b/src/DevBetterWeb.Web/Endpoints/StripeWebhookEndpoints/CustomerSubscriptionUpdatedWebHook.cs
@@ -57,7 +57,7 @@ public class CustomerSubscriptionUpdatedWebHook : EndpointBaseAsync
 
 			_logger.LogInformation($"Processing Stripe Event Type: {stripeEvent.Type}");
 
-			if (stripeEvent.Type != EventTypes.CustomerUpdated)
+			if (stripeEvent.Type != EventTypes.CustomerSubscriptionUpdated)
 			{
 				throw new Exception($"Unhandled Stripe event type {stripeEvent.Type}");
 			}

--- a/src/DevBetterWeb.Web/MappingProfiles/SubscriptionProfile.cs
+++ b/src/DevBetterWeb.Web/MappingProfiles/SubscriptionProfile.cs
@@ -1,0 +1,28 @@
+using System.Linq;
+using AutoMapper;
+using DevBetterWeb.Web.Models;
+using Stripe;
+
+namespace DevBetterWeb.Web.MappingProfiles;
+
+public class SubscriptionProfile : Profile
+{
+	public SubscriptionProfile()
+	{
+		CreateMap<Subscription, StripeSubscriptionDto>()
+			.ForMember(dest => dest.CustomerEmail,
+				opt => opt.MapFrom((src, _) => src.Customer?.Email ?? string.Empty))
+			.ForMember(dest => dest.PlanName,
+				opt => opt.MapFrom((src, _) => src.Items?.Data?.FirstOrDefault()?.Price?.Nickname ?? string.Empty))
+			.ForMember(dest => dest.Amount,
+				opt => opt.MapFrom((src, _) => (src.Items?.Data?.FirstOrDefault()?.Price?.UnitAmountDecimal ?? 0m) / 100m))
+			.ForMember(dest => dest.Currency,
+				opt => opt.MapFrom((src, _) => src.Items?.Data?.FirstOrDefault()?.Price?.Currency ?? string.Empty))
+			.ForMember(dest => dest.Interval,
+				opt => opt.MapFrom((src, _) => src.Items?.Data?.FirstOrDefault()?.Price?.Recurring?.Interval ?? string.Empty))
+			.ForMember(dest => dest.CurrentPeriodEnd,
+				opt => opt.MapFrom((src, _) => src.Items?.Data?.FirstOrDefault()?.CurrentPeriodEnd ?? default))
+			.ForMember(dest => dest.IsPaused,
+				opt => opt.MapFrom((src, _) => src.PauseCollection != null));
+	}
+}

--- a/src/DevBetterWeb.Web/Models/StripeSubscriptionDto.cs
+++ b/src/DevBetterWeb.Web/Models/StripeSubscriptionDto.cs
@@ -1,0 +1,18 @@
+using System;
+
+namespace DevBetterWeb.Web.Models;
+
+public class StripeSubscriptionDto
+{
+	public string Id { get; set; } = string.Empty;
+	public string Status { get; set; } = string.Empty;
+	public string CustomerId { get; set; } = string.Empty;
+	public string CustomerEmail { get; set; } = string.Empty;
+	public string PlanName { get; set; } = string.Empty;
+	public decimal Amount { get; set; }
+	public string Currency { get; set; } = string.Empty;
+	public string Interval { get; set; } = string.Empty;
+	public DateTime CurrentPeriodEnd { get; set; }
+	public bool CancelAtPeriodEnd { get; set; }
+	public bool IsPaused { get; set; }
+}

--- a/src/DevBetterWeb.Web/Pages/Admin/Index.cshtml
+++ b/src/DevBetterWeb.Web/Pages/Admin/Index.cshtml
@@ -42,6 +42,11 @@
         </a>
     </li>
     <li class="list-group-item list-group-item-action">
+        <a href="./Admin/ManageSubscriptions">
+            <i class="fas fa-credit-card fa-fw" aria-hidden="true"></i> Manage Subscriptions
+        </a>
+    </li>
+    <li class="list-group-item list-group-item-action">
         <a href="./Admin/UserReports">
             <i class="fas fa-file-alt fa-fw" aria-hidden="true"></i> View Reports
         </a>

--- a/src/DevBetterWeb.Web/Pages/Admin/ManageSubscriptions/Index.cshtml
+++ b/src/DevBetterWeb.Web/Pages/Admin/ManageSubscriptions/Index.cshtml
@@ -1,0 +1,58 @@
+@page
+@model DevBetterWeb.Web.Pages.Admin.ManageSubscriptions.IndexModel
+
+@{
+	ViewData["Title"] = "Manage Subscriptions";
+}
+
+<h2>Manage Subscriptions</h2>
+
+@if (!string.IsNullOrEmpty(Model.StatusMessage))
+{
+	<div class="alert alert-info">@Model.StatusMessage</div>
+}
+
+<div class="card">
+	<div class="card-header">
+		<b>Billable Stripe Subscriptions (@Model.Subscriptions.Count)</b>
+	</div>
+	<div class="card-body" style="overflow: auto;">
+		<table class="table">
+			<thead>
+			<tr>
+				<th>Customer Email</th>
+				<th>Plan</th>
+				<th>Amount</th>
+				<th>Interval</th>
+				<th>Status</th>
+				<th>Current Period End</th>
+				<th>Actions</th>
+			</tr>
+			</thead>
+			<tbody>
+			@foreach (var subscription in Model.Subscriptions)
+			{
+				<tr>
+					<td>@subscription.CustomerEmail<br /><small class="text-muted">@subscription.Id</small></td>
+					<td>@subscription.PlanName</td>
+					<td>$@subscription.Amount.ToString("F2") @subscription.Currency.ToUpper()</td>
+					<td>@subscription.Interval</td>
+					<td>
+						@subscription.Status
+						@if (subscription.IsPaused)
+						{
+							<span class="badge badge-warning">Paused</span>
+						}
+						@if (subscription.CancelAtPeriodEnd)
+						{
+							<span class="badge badge-secondary">Cancels at period end</span>
+						}
+					</td>
+					<td>@subscription.CurrentPeriodEnd.ToString("MM/dd/yyyy")</td>
+					<td><!-- Action buttons added in Task 6 --></td>
+				</tr>
+			}
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/src/DevBetterWeb.Web/Pages/Admin/ManageSubscriptions/Index.cshtml
+++ b/src/DevBetterWeb.Web/Pages/Admin/ManageSubscriptions/Index.cshtml
@@ -60,7 +60,7 @@
 						else
 						{
 							<form method="post" asp-page-handler="Pause" style="display:inline"
-							      onsubmit="return confirm('Pause collection for @subscription.CustomerEmail? Stripe will stop charging until resumed.');">
+							      onsubmit="return confirm('Pause collection for this customer? Stripe will stop charging until resumed.');">
 								<input type="hidden" name="subscriptionId" value="@subscription.Id" />
 								<button type="submit" class="btn btn-sm btn-warning">Pause</button>
 							</form>
@@ -68,13 +68,13 @@
 						@if (!subscription.CancelAtPeriodEnd)
 						{
 							<form method="post" asp-page-handler="Cancel" style="display:inline"
-							      onsubmit="return confirm('Cancel @subscription.CustomerEmail at period end?');">
+							      onsubmit="return confirm('Cancel this subscription at period end?');">
 								<input type="hidden" name="subscriptionId" value="@subscription.Id" />
 								<button type="submit" class="btn btn-sm btn-outline-danger">Cancel at Period End</button>
 							</form>
 						}
 						<form method="post" asp-page-handler="CancelNow" style="display:inline"
-						      onsubmit="return confirm('IMMEDIATELY cancel @subscription.Id for @subscription.CustomerEmail? This cannot be undone.');">
+						      onsubmit="return confirm('IMMEDIATELY cancel this subscription? This cannot be undone.');">
 							<input type="hidden" name="subscriptionId" value="@subscription.Id" />
 							<button type="submit" class="btn btn-sm btn-danger">Cancel Now</button>
 						</form>

--- a/src/DevBetterWeb.Web/Pages/Admin/ManageSubscriptions/Index.cshtml
+++ b/src/DevBetterWeb.Web/Pages/Admin/ManageSubscriptions/Index.cshtml
@@ -49,7 +49,36 @@
 						}
 					</td>
 					<td>@subscription.CurrentPeriodEnd.ToString("MM/dd/yyyy")</td>
-					<td><!-- Action buttons added in Task 6 --></td>
+					<td style="white-space: nowrap;">
+						@if (subscription.IsPaused)
+						{
+							<form method="post" asp-page-handler="Resume" style="display:inline">
+								<input type="hidden" name="subscriptionId" value="@subscription.Id" />
+								<button type="submit" class="btn btn-sm btn-success">Resume</button>
+							</form>
+						}
+						else
+						{
+							<form method="post" asp-page-handler="Pause" style="display:inline"
+							      onsubmit="return confirm('Pause collection for @subscription.CustomerEmail? Stripe will stop charging until resumed.');">
+								<input type="hidden" name="subscriptionId" value="@subscription.Id" />
+								<button type="submit" class="btn btn-sm btn-warning">Pause</button>
+							</form>
+						}
+						@if (!subscription.CancelAtPeriodEnd)
+						{
+							<form method="post" asp-page-handler="Cancel" style="display:inline"
+							      onsubmit="return confirm('Cancel @subscription.CustomerEmail at period end?');">
+								<input type="hidden" name="subscriptionId" value="@subscription.Id" />
+								<button type="submit" class="btn btn-sm btn-outline-danger">Cancel at Period End</button>
+							</form>
+						}
+						<form method="post" asp-page-handler="CancelNow" style="display:inline"
+						      onsubmit="return confirm('IMMEDIATELY cancel @subscription.Id for @subscription.CustomerEmail? This cannot be undone.');">
+							<input type="hidden" name="subscriptionId" value="@subscription.Id" />
+							<button type="submit" class="btn btn-sm btn-danger">Cancel Now</button>
+						</form>
+					</td>
 				</tr>
 			}
 			</tbody>

--- a/src/DevBetterWeb.Web/Pages/Admin/ManageSubscriptions/Index.cshtml.cs
+++ b/src/DevBetterWeb.Web/Pages/Admin/ManageSubscriptions/Index.cshtml.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using AutoMapper;
+using DevBetterWeb.Core;
+using DevBetterWeb.Infrastructure.Interfaces;
+using DevBetterWeb.Web.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace DevBetterWeb.Web.Pages.Admin.ManageSubscriptions;
+
+[Authorize(Roles = AuthConstants.Roles.ADMINISTRATORS)]
+public class IndexModel : PageModel
+{
+	private readonly ISubscriptionHandlerService _subscriptionHandlerService;
+	private readonly IMapper _mapper;
+
+	public List<StripeSubscriptionDto> Subscriptions { get; private set; } = new();
+
+	[TempData]
+	public string? StatusMessage { get; set; }
+
+	public IndexModel(ISubscriptionHandlerService subscriptionHandlerService, IMapper mapper)
+	{
+		_subscriptionHandlerService = subscriptionHandlerService;
+		_mapper = mapper;
+	}
+
+	public async Task OnGetAsync()
+	{
+		var subscriptions = await _subscriptionHandlerService.ListBillableAsync(HttpContext.RequestAborted);
+		Subscriptions = _mapper.Map<List<StripeSubscriptionDto>>(subscriptions)
+			.OrderBy(s => s.CustomerEmail)
+			.ThenBy(s => s.Id)
+			.ToList();
+	}
+}

--- a/src/DevBetterWeb.Web/Pages/Admin/ManageSubscriptions/Index.cshtml.cs
+++ b/src/DevBetterWeb.Web/Pages/Admin/ManageSubscriptions/Index.cshtml.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -8,6 +9,7 @@ using DevBetterWeb.Web.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Stripe;
 
 namespace DevBetterWeb.Web.Pages.Admin.ManageSubscriptions;
 
@@ -35,5 +37,43 @@ public class IndexModel : PageModel
 			.OrderBy(s => s.CustomerEmail)
 			.ThenBy(s => s.Id)
 			.ToList();
+	}
+
+	public Task<IActionResult> OnPostPauseAsync(string subscriptionId)
+		=> ExecuteActionAsync(subscriptionId, id => _subscriptionHandlerService.PauseAsync(id, HttpContext.RequestAborted),
+			"paused (Stripe will not charge until resumed)");
+
+	public Task<IActionResult> OnPostResumeAsync(string subscriptionId)
+		=> ExecuteActionAsync(subscriptionId, id => _subscriptionHandlerService.ResumeAsync(id, HttpContext.RequestAborted),
+			"resumed");
+
+	public Task<IActionResult> OnPostCancelAsync(string subscriptionId)
+		=> ExecuteActionAsync(subscriptionId, id => _subscriptionHandlerService.CancelAtPeriodEndAsync(id, HttpContext.RequestAborted),
+			"set to cancel at period end");
+
+	public Task<IActionResult> OnPostCancelNowAsync(string subscriptionId)
+		=> ExecuteActionAsync(subscriptionId, id => _subscriptionHandlerService.CancelImmediatelyAsync(id, HttpContext.RequestAborted),
+			"canceled immediately");
+
+	private async Task<IActionResult> ExecuteActionAsync(string subscriptionId,
+		Func<string, Task<Subscription>> action, string successVerb)
+	{
+		if (string.IsNullOrWhiteSpace(subscriptionId))
+		{
+			StatusMessage = "No subscription id provided.";
+			return RedirectToPage();
+		}
+
+		try
+		{
+			await action(subscriptionId);
+			StatusMessage = $"Subscription {subscriptionId} {successVerb}.";
+		}
+		catch (StripeException exception)
+		{
+			StatusMessage = $"Stripe error for {subscriptionId}: {exception.Message}";
+		}
+
+		return RedirectToPage();
 	}
 }

--- a/tests/DevBetterWeb.Tests/MappingProfiles/SubscriptionProfileTests.cs
+++ b/tests/DevBetterWeb.Tests/MappingProfiles/SubscriptionProfileTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using AutoMapper;
+using DevBetterWeb.Web.MappingProfiles;
+using DevBetterWeb.Web.Models;
+using Microsoft.Extensions.Logging.Abstractions;
+using Stripe;
+using Xunit;
+
+namespace DevBetterWeb.Tests.MappingProfiles;
+
+public class SubscriptionProfileTests
+{
+	private readonly IMapper _mapper;
+
+	public SubscriptionProfileTests()
+	{
+		var configuration = new MapperConfiguration(
+			cfg => cfg.AddProfile<SubscriptionProfile>(),
+			NullLoggerFactory.Instance);
+		_mapper = configuration.CreateMapper();
+	}
+
+	[Fact]
+	public void MapsSubscriptionToDto()
+	{
+		var subscription = new Subscription
+		{
+			Id = "sub_123",
+			Status = "active",
+			CustomerId = "cus_123",
+			Customer = new Customer { Id = "cus_123", Email = "member@example.com" },
+			CancelAtPeriodEnd = true,
+			PauseCollection = new SubscriptionPauseCollection { Behavior = "void" },
+			Items = new StripeList<SubscriptionItem>
+			{
+				Data = new List<SubscriptionItem>
+				{
+					new SubscriptionItem
+					{
+						CurrentPeriodEnd = new DateTime(2026, 8, 27, 0, 0, 0, DateTimeKind.Utc),
+						Price = new Price
+						{
+							Nickname = "Monthly",
+							UnitAmountDecimal = 20000m,
+							Currency = "usd",
+							Recurring = new PriceRecurring { Interval = "month" },
+						},
+					},
+				},
+			},
+		};
+
+		var dto = _mapper.Map<StripeSubscriptionDto>(subscription);
+
+		Assert.Equal("sub_123", dto.Id);
+		Assert.Equal("active", dto.Status);
+		Assert.Equal("cus_123", dto.CustomerId);
+		Assert.Equal("member@example.com", dto.CustomerEmail);
+		Assert.Equal("Monthly", dto.PlanName);
+		Assert.Equal(200m, dto.Amount);
+		Assert.Equal("usd", dto.Currency);
+		Assert.Equal("month", dto.Interval);
+		Assert.Equal(new DateTime(2026, 8, 27, 0, 0, 0, DateTimeKind.Utc), dto.CurrentPeriodEnd);
+		Assert.True(dto.CancelAtPeriodEnd);
+		Assert.True(dto.IsPaused);
+	}
+
+	[Fact]
+	public void MapsSubscriptionWithMissingOptionalDataWithoutThrowing()
+	{
+		var subscription = new Subscription { Id = "sub_bare", Status = "active" };
+
+		var dto = _mapper.Map<StripeSubscriptionDto>(subscription);
+
+		Assert.Equal("sub_bare", dto.Id);
+		Assert.Equal(string.Empty, dto.CustomerEmail);
+		Assert.False(dto.IsPaused);
+		Assert.Equal(0m, dto.Amount);
+	}
+}

--- a/tests/DevBetterWeb.Tests/Pages/ManageSubscriptionsIndexModelTests/OnGetAsync.cs
+++ b/tests/DevBetterWeb.Tests/Pages/ManageSubscriptionsIndexModelTests/OnGetAsync.cs
@@ -32,17 +32,45 @@ public class OnGetAsync
 	[Fact]
 	public async Task LoadsBillableSubscriptionsAsDtos()
 	{
+		// Provide subscriptions in non-sorted order; include same-email pair for ThenBy(Id) tie-break
 		_subscriptionHandlerService.ListBillableAsync(Arg.Any<CancellationToken>()).Returns(
 			new List<Subscription>
 			{
-				new Subscription { Id = "sub_b", Status = "active" },
-				new Subscription { Id = "sub_a", Status = "past_due" },
+				new Subscription
+				{
+					Id = "sub_c",
+					Status = "active",
+					Customer = new Customer { Email = "charlie@example.com" }
+				},
+				new Subscription
+				{
+					Id = "sub_a",
+					Status = "active",
+					Customer = new Customer { Email = "alice@example.com" }
+				},
+				new Subscription
+				{
+					Id = "sub_b",
+					Status = "past_due",
+					Customer = new Customer { Email = "alice@example.com" }
+				},
 			});
 
 		await _pageModel.OnGetAsync();
 
-		Assert.Equal(2, _pageModel.Subscriptions.Count);
-		Assert.Contains(_pageModel.Subscriptions, s => s.Id == "sub_a");
-		Assert.Contains(_pageModel.Subscriptions, s => s.Id == "sub_b");
+		// Verify all three loaded and sorted by CustomerEmail then Id
+		Assert.Equal(3, _pageModel.Subscriptions.Count);
+
+		// First result: alice@example.com, sub_a (sorts before sub_b because a < b)
+		Assert.Equal("alice@example.com", _pageModel.Subscriptions[0].CustomerEmail);
+		Assert.Equal("sub_a", _pageModel.Subscriptions[0].Id);
+
+		// Second result: alice@example.com, sub_b (same email, sorts by ID)
+		Assert.Equal("alice@example.com", _pageModel.Subscriptions[1].CustomerEmail);
+		Assert.Equal("sub_b", _pageModel.Subscriptions[1].Id);
+
+		// Third result: charlie@example.com, sub_c (sorts after alice emails)
+		Assert.Equal("charlie@example.com", _pageModel.Subscriptions[2].CustomerEmail);
+		Assert.Equal("sub_c", _pageModel.Subscriptions[2].Id);
 	}
 }

--- a/tests/DevBetterWeb.Tests/Pages/ManageSubscriptionsIndexModelTests/OnGetAsync.cs
+++ b/tests/DevBetterWeb.Tests/Pages/ManageSubscriptionsIndexModelTests/OnGetAsync.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using DevBetterWeb.Infrastructure.Interfaces;
+using DevBetterWeb.Web.MappingProfiles;
+using DevBetterWeb.Web.Pages.Admin.ManageSubscriptions;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Stripe;
+using Xunit;
+
+namespace DevBetterWeb.Tests.Pages.ManageSubscriptionsIndexModelTests;
+
+public class OnGetAsync
+{
+	private readonly ISubscriptionHandlerService _subscriptionHandlerService = Substitute.For<ISubscriptionHandlerService>();
+	private readonly IndexModel _pageModel;
+
+	public OnGetAsync()
+	{
+		var configuration = new MapperConfiguration(
+			cfg => cfg.AddProfile<SubscriptionProfile>(),
+			NullLoggerFactory.Instance);
+		_pageModel = new IndexModel(_subscriptionHandlerService, configuration.CreateMapper());
+		_pageModel.PageContext = new Microsoft.AspNetCore.Mvc.RazorPages.PageContext
+		{
+			HttpContext = new Microsoft.AspNetCore.Http.DefaultHttpContext(),
+		};
+	}
+
+	[Fact]
+	public async Task LoadsBillableSubscriptionsAsDtos()
+	{
+		_subscriptionHandlerService.ListBillableAsync(Arg.Any<CancellationToken>()).Returns(
+			new List<Subscription>
+			{
+				new Subscription { Id = "sub_b", Status = "active" },
+				new Subscription { Id = "sub_a", Status = "past_due" },
+			});
+
+		await _pageModel.OnGetAsync();
+
+		Assert.Equal(2, _pageModel.Subscriptions.Count);
+		Assert.Contains(_pageModel.Subscriptions, s => s.Id == "sub_a");
+		Assert.Contains(_pageModel.Subscriptions, s => s.Id == "sub_b");
+	}
+}

--- a/tests/DevBetterWeb.Tests/Pages/ManageSubscriptionsIndexModelTests/PostHandlers.cs
+++ b/tests/DevBetterWeb.Tests/Pages/ManageSubscriptionsIndexModelTests/PostHandlers.cs
@@ -1,0 +1,90 @@
+using System.Threading;
+using System.Threading.Tasks;
+using AutoMapper;
+using DevBetterWeb.Infrastructure.Interfaces;
+using DevBetterWeb.Web.MappingProfiles;
+using DevBetterWeb.Web.Pages.Admin.ManageSubscriptions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Stripe;
+using Xunit;
+
+namespace DevBetterWeb.Tests.Pages.ManageSubscriptionsIndexModelTests;
+
+public class PostHandlers
+{
+	private const string SubscriptionId = "sub_123";
+	private readonly ISubscriptionHandlerService _subscriptionHandlerService = Substitute.For<ISubscriptionHandlerService>();
+	private readonly IndexModel _pageModel;
+
+	public PostHandlers()
+	{
+		var configuration = new MapperConfiguration(
+			cfg => cfg.AddProfile<SubscriptionProfile>(),
+			NullLoggerFactory.Instance);
+		_pageModel = new IndexModel(_subscriptionHandlerService, configuration.CreateMapper());
+		_pageModel.PageContext = new PageContext { HttpContext = new DefaultHttpContext() };
+	}
+
+	[Fact]
+	public async Task PausePausesSubscriptionAndRedirects()
+	{
+		var result = await _pageModel.OnPostPauseAsync(SubscriptionId);
+
+		await _subscriptionHandlerService.Received(1).PauseAsync(SubscriptionId, Arg.Any<CancellationToken>());
+		Assert.IsType<RedirectToPageResult>(result);
+		Assert.Contains("paused", _pageModel.StatusMessage);
+	}
+
+	[Fact]
+	public async Task ResumeResumesSubscriptionAndRedirects()
+	{
+		var result = await _pageModel.OnPostResumeAsync(SubscriptionId);
+
+		await _subscriptionHandlerService.Received(1).ResumeAsync(SubscriptionId, Arg.Any<CancellationToken>());
+		Assert.IsType<RedirectToPageResult>(result);
+	}
+
+	[Fact]
+	public async Task CancelCancelsAtPeriodEndAndRedirects()
+	{
+		var result = await _pageModel.OnPostCancelAsync(SubscriptionId);
+
+		await _subscriptionHandlerService.Received(1).CancelAtPeriodEndAsync(SubscriptionId, Arg.Any<CancellationToken>());
+		Assert.IsType<RedirectToPageResult>(result);
+	}
+
+	[Fact]
+	public async Task CancelNowCancelsImmediatelyAndRedirects()
+	{
+		var result = await _pageModel.OnPostCancelNowAsync(SubscriptionId);
+
+		await _subscriptionHandlerService.Received(1).CancelImmediatelyAsync(SubscriptionId, Arg.Any<CancellationToken>());
+		Assert.IsType<RedirectToPageResult>(result);
+	}
+
+	[Fact]
+	public async Task StripeErrorIsReportedInStatusMessageNotThrown()
+	{
+		_subscriptionHandlerService.PauseAsync(SubscriptionId, Arg.Any<CancellationToken>())
+			.Returns<Task<Subscription>>(_ => throw new StripeException("No such subscription"));
+
+		var result = await _pageModel.OnPostPauseAsync(SubscriptionId);
+
+		Assert.IsType<RedirectToPageResult>(result);
+		Assert.Contains("No such subscription", _pageModel.StatusMessage);
+	}
+
+	[Fact]
+	public async Task MissingSubscriptionIdIsRejectedWithoutCallingStripe()
+	{
+		var result = await _pageModel.OnPostPauseAsync("");
+
+		await _subscriptionHandlerService.DidNotReceiveWithAnyArgs().PauseAsync(default!, default);
+		Assert.IsType<RedirectToPageResult>(result);
+	}
+}

--- a/tests/DevBetterWeb.Tests/Services/StripeSubscriptionHandlerServiceTests/CancelAsync.cs
+++ b/tests/DevBetterWeb.Tests/Services/StripeSubscriptionHandlerServiceTests/CancelAsync.cs
@@ -1,0 +1,46 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DevBetterWeb.Infrastructure.SubscriptionHandler.StripeSubscriptionHandler;
+using NSubstitute;
+using Stripe;
+using Xunit;
+
+namespace DevBetterWeb.Tests.Services.StripeSubscriptionHandlerServiceTests;
+
+public class CancelAsync
+{
+	private const string SubscriptionId = "sub_123";
+	private readonly SubscriptionService _stripeSubscriptionService = Substitute.For<SubscriptionService>();
+	private readonly StripeSubscriptionHandlerService _service;
+
+	public CancelAsync()
+	{
+		_stripeSubscriptionService
+			.UpdateAsync(SubscriptionId, Arg.Any<SubscriptionUpdateOptions>(), Arg.Any<RequestOptions>(), Arg.Any<CancellationToken>())
+			.Returns(new Subscription { Id = SubscriptionId });
+		_stripeSubscriptionService
+			.CancelAsync(SubscriptionId, Arg.Any<SubscriptionCancelOptions>(), Arg.Any<RequestOptions>(), Arg.Any<CancellationToken>())
+			.Returns(new Subscription { Id = SubscriptionId, Status = "canceled" });
+		_service = new StripeSubscriptionHandlerService(_stripeSubscriptionService);
+	}
+
+	[Fact]
+	public async Task CancelAtPeriodEndSetsFlagOnSubscription()
+	{
+		await _service.CancelAtPeriodEndAsync(SubscriptionId);
+
+		await _stripeSubscriptionService.Received(1).UpdateAsync(SubscriptionId,
+			Arg.Is<SubscriptionUpdateOptions>(o => o.CancelAtPeriodEnd == true),
+			Arg.Any<RequestOptions>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task CancelImmediatelyCallsStripeCancel()
+	{
+		var result = await _service.CancelImmediatelyAsync(SubscriptionId);
+
+		Assert.Equal("canceled", result.Status);
+		await _stripeSubscriptionService.Received(1).CancelAsync(SubscriptionId,
+			Arg.Any<SubscriptionCancelOptions>(), Arg.Any<RequestOptions>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/DevBetterWeb.Tests/Services/StripeSubscriptionHandlerServiceTests/ListBillableAsync.cs
+++ b/tests/DevBetterWeb.Tests/Services/StripeSubscriptionHandlerServiceTests/ListBillableAsync.cs
@@ -1,0 +1,56 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using DevBetterWeb.Infrastructure.SubscriptionHandler.StripeSubscriptionHandler;
+using NSubstitute;
+using Stripe;
+using Xunit;
+
+namespace DevBetterWeb.Tests.Services.StripeSubscriptionHandlerServiceTests;
+
+public class ListBillableAsync
+{
+	private readonly SubscriptionService _stripeSubscriptionService = Substitute.For<SubscriptionService>();
+
+	[Fact]
+	public async Task ReturnsOnlyBillableStatusesAndExcludesCanceled()
+	{
+		var page = new StripeList<Subscription>
+		{
+			HasMore = false,
+			Data = new List<Subscription>
+			{
+				new Subscription { Id = "sub_active", Status = "active" },
+				new Subscription { Id = "sub_pastdue", Status = "past_due" },
+				new Subscription { Id = "sub_canceled", Status = "canceled" },
+				new Subscription { Id = "sub_incomplete", Status = "incomplete_expired" },
+			},
+		};
+		_stripeSubscriptionService
+			.ListAsync(Arg.Any<SubscriptionListOptions>(), Arg.Any<RequestOptions>(), Arg.Any<CancellationToken>())
+			.Returns(page);
+		var service = new StripeSubscriptionHandlerService(_stripeSubscriptionService);
+
+		var result = await service.ListBillableAsync();
+
+		Assert.Equal(2, result.Count);
+		Assert.Contains(result, s => s.Id == "sub_active");
+		Assert.Contains(result, s => s.Id == "sub_pastdue");
+		Assert.DoesNotContain(result, s => s.Id == "sub_canceled");
+	}
+
+	[Fact]
+	public async Task RequestsAllStatusesWithCustomerExpanded()
+	{
+		_stripeSubscriptionService
+			.ListAsync(Arg.Any<SubscriptionListOptions>(), Arg.Any<RequestOptions>(), Arg.Any<CancellationToken>())
+			.Returns(new StripeList<Subscription> { HasMore = false, Data = new List<Subscription>() });
+		var service = new StripeSubscriptionHandlerService(_stripeSubscriptionService);
+
+		await service.ListBillableAsync();
+
+		await _stripeSubscriptionService.Received(1).ListAsync(
+			Arg.Is<SubscriptionListOptions>(o => o.Status == "all" && o.Expand.Contains("data.customer")),
+			Arg.Any<RequestOptions>(), Arg.Any<CancellationToken>());
+	}
+}

--- a/tests/DevBetterWeb.Tests/Services/StripeSubscriptionHandlerServiceTests/PauseAndResumeAsync.cs
+++ b/tests/DevBetterWeb.Tests/Services/StripeSubscriptionHandlerServiceTests/PauseAndResumeAsync.cs
@@ -1,0 +1,47 @@
+using System.Threading;
+using System.Threading.Tasks;
+using DevBetterWeb.Infrastructure.SubscriptionHandler.StripeSubscriptionHandler;
+using NSubstitute;
+using Stripe;
+using Xunit;
+
+namespace DevBetterWeb.Tests.Services.StripeSubscriptionHandlerServiceTests;
+
+public class PauseAndResumeAsync
+{
+	private const string SubscriptionId = "sub_123";
+	private readonly SubscriptionService _stripeSubscriptionService = Substitute.For<SubscriptionService>();
+	private readonly StripeSubscriptionHandlerService _service;
+
+	public PauseAndResumeAsync()
+	{
+		_stripeSubscriptionService
+			.UpdateAsync(SubscriptionId, Arg.Any<SubscriptionUpdateOptions>(), Arg.Any<RequestOptions>(), Arg.Any<CancellationToken>())
+			.Returns(new Subscription { Id = SubscriptionId });
+		_service = new StripeSubscriptionHandlerService(_stripeSubscriptionService);
+	}
+
+	[Fact]
+	public async Task PauseUpdatesSubscriptionWithVoidPauseBehavior()
+	{
+		await _service.PauseAsync(SubscriptionId);
+
+		await _stripeSubscriptionService.Received(1).UpdateAsync(SubscriptionId,
+			Arg.Is<SubscriptionUpdateOptions>(o =>
+				o.PauseCollection != null && o.PauseCollection.Behavior == "void"),
+			Arg.Any<RequestOptions>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task ResumeUpdatesSubscriptionClearingPauseCollection()
+	{
+		await _service.ResumeAsync(SubscriptionId);
+
+		// Clearing pause_collection requires sending an empty value; Stripe.net does this
+		// via AddExtraParam, which lands in the options' ExtraParams dictionary.
+		await _stripeSubscriptionService.Received(1).UpdateAsync(SubscriptionId,
+			Arg.Is<SubscriptionUpdateOptions>(o =>
+				o.ExtraParams != null && o.ExtraParams.ContainsKey("pause_collection")),
+			Arg.Any<RequestOptions>(), Arg.Any<CancellationToken>());
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ISubscriptionHandlerService` with billable subscription listing, pause/resume, and cancel (at period end or immediately) operations against Stripe
- Adds `StripeSubscriptionDto` and AutoMapper profile for mapping Stripe subscriptions
- Adds admin **Manage Subscriptions** page listing billable subscriptions with pause, resume, and cancel actions
- Fixes XSS, loop, and webhook findings from code review of the new page

## Test plan
- [x] `dotnet build` — 0 warnings, 0 errors
- [x] `dotnet test` — 232 passed, 0 failed (Tests: 75, UnitTests: 154, FunctionalTests: 3)
- [ ] Manual: verify Manage Subscriptions page as admin against Stripe test data

🤖 Generated with [Claude Code](https://claude.com/claude-code)