### PR TITLE
Fix Stripe webhook endpoints returning 500s to Stripe

### DIFF
--- a/.claude/skills/implement-feature/SKILL.md
+++ b/.claude/skills/implement-feature/SKILL.md
@@ -1,0 +1,127 @@
+---
+name: implement-feature
+description: End-to-end workflow for implementing, fixing, or otherwise working on a specific GitHub issue. Fetches full issue context with the gh CLI, produces a phased implementation plan in .claude/plans, implements it, gets an independent agent review, verifies build/tests/format, and opens a pull request that references the issue. Use whenever asked to implement, fix, or work on a GitHub issue by number or URL.
+metadata:
+  author: nimblepros
+  version: "1.0"
+  spec: agentskills.io
+---
+
+# Implement Feature from GitHub Issue
+
+## Purpose
+
+Provide a repeatable, verifiable workflow for taking a GitHub issue from "assigned" to
+"pull request open":
+
+1. Gather complete issue context (body, images, comments, linked issues/PRs).
+2. Persist a phased implementation plan in `.claude/plans`.
+3. Implement, test, and independently review the changes.
+4. Verify build, tests, and formatting are clean.
+5. Open a pull request that closes the issue.
+
+## Use This Skill When
+
+- Asked to implement, fix, resolve, or "work on" a specific GitHub issue (by number or URL).
+- Picking up an issue from a milestone or project board.
+- Resuming work on an issue that already has a plan in `.claude/plans` (skip to the
+  implementation step and follow the existing plan).
+
+## Workflow
+
+### 1. Gather full issue context
+
+Use the `gh` CLI — never guess at issue content:
+
+- `gh issue view <number> --json title,body,labels,assignees,milestone,comments,url`
+- Review **all** comments, not just the body. Later comments often change or narrow scope.
+- Download and view every image/attachment referenced in the body or comments
+  (`user-images.githubusercontent.com` / `github.com/user-attachments` URLs). Screenshots
+  frequently contain the actual acceptance criteria.
+- Follow every referenced issue and PR (`#NNN` mentions, "relates to", "blocked by",
+  "duplicate of") with `gh issue view` / `gh pr view` and read enough of each to understand
+  how it affects scope.
+- Note labels (bug vs. enhancement, area labels) and milestone — they signal intent and
+  urgency.
+
+If, after all of this, the acceptance criteria are still ambiguous, state your assumptions
+explicitly in the plan rather than silently choosing.
+
+### 2. Create and persist an implementation plan
+
+Write a phased, task-based markdown plan to `.claude/plans/` **before writing any code**.
+
+ALWAYS start from the `main` branch with latest changes pulled.
+
+- Filename: `YYYY-MM-DD-issue-NNN-short-slug.md` (today's date, the issue number, and a
+  short kebab-case summary), matching existing files in that folder.
+- Structure the plan as numbered phases, each with a checklist of concrete tasks
+  (`- [ ] ...`). Include the issue number and link at the top.
+- The plan **must** include:
+  - **Automated test requirements** — which behaviors get unit / integration / e2e
+    coverage, in which test project(s).
+  - **A final review phase** — a comprehensive review of the full change set by a
+    **separate agent** (fresh context, not the implementing agent), with a task to address
+    all significant findings from that review.
+  - **A final verification phase** — the application builds, all tests pass, and
+    `dotnet format` produces no changes. In this repo that means running
+    `dotnet BuildTestFormat.cs` and getting a clean result.
+- Check the plan boxes off as work proceeds so the plan reflects actual progress.
+
+### 3. Implement the plan
+
+- Work through the phases in order; keep commits scoped and coherent.
+- Create a feature branch first (e.g. `issue-NNN-short-slug` or `feature/...`, matching
+  recent branch names in the repo) — never commit directly to `main`.
+- Follow repo conventions: `.editorconfig`, existing project structure, and any relevant
+  skills (test authoring, EF Core patterns, etc.).
+- Write the automated tests the plan calls for — tests are part of the implementation, not
+  an optional follow-up.
+
+### 4. Independent review
+
+- Launch a **separate review agent** (fresh context) to review the complete diff against
+  the issue's acceptance criteria: correctness, missed requirements, test coverage gaps,
+  and regressions.
+- Address **all significant findings**. For findings deliberately not addressed, record the
+  reasoning in the plan file.
+- If the review produced changes, re-run verification afterward.
+
+### 5. Final verification
+
+Confirm (or re-confirm, if step 4 changed anything):
+
+- The full solution builds with no errors.
+- All tests pass.
+- `dotnet format` reports nothing to change.
+
+In this repo, `dotnet BuildTestFormat.cs` covers all three — it must complete cleanly
+before moving on. Never skip, weaken, or disable tests to get to green.
+
+### 6. Create the pull request
+
+- Push the branch and open a PR with `gh pr create` targeting the default branch.
+- The PR body must include:
+  - A summary of all changes, organized by area if the change set is large.
+  - The test coverage added and the verification performed.
+  - `Fixes #NNN` (or `Closes #NNN`) for each issue the PR resolves, so merging closes
+    them. Use `Relates to #NNN` for issues touched but not fully resolved.
+
+### 7. Summarize in chat
+
+End with a chat summary covering:
+
+- What the issue asked for and what was delivered.
+- The plan file path, branch name, and PR URL.
+- Test coverage added and verification results (build/tests/format).
+- Any review findings addressed, assumptions made, or follow-up work deferred.
+
+## Guardrails
+
+- Do not start implementing before the plan file exists in `.claude/plans`.
+- Do not claim the work is complete unless `dotnet BuildTestFormat.cs` ran cleanly after
+  the last code change.
+- Do not mark review findings as addressed without actually changing the code or recording
+  an explicit reason for skipping them.
+- Report failures honestly: if tests fail or the review surfaced unresolved problems, say
+  so in the summary instead of papering over it.

--- a/src/DevBetterWeb.Web/Endpoints/StripeWebhookEndpoints/CustomerSubscriptionDeletedWebHook.cs
+++ b/src/DevBetterWeb.Web/Endpoints/StripeWebhookEndpoints/CustomerSubscriptionDeletedWebHook.cs
@@ -43,16 +43,23 @@ public class CustomerSubscriptionDeletedWebHook : EndpointBaseAsync
 			json = await streamReader.ReadToEndAsync();
 		}
 
+		string? signatureHeader = Request.Headers["Stripe-Signature"];
+		if (string.IsNullOrEmpty(signatureHeader))
+		{
+			_logger.LogWarning("Missing Stripe-Signature header");
+			return BadRequest("Missing Stripe-Signature header");
+		}
+
 		try
 		{
-			var stripeEvent = EventUtility.ConstructEvent(json,
-				Request.Headers["Stripe-Signature"], _stripeWebHookSecretKey);
+			var stripeEvent = EventUtility.ConstructEvent(json, signatureHeader, _stripeWebHookSecretKey);
 
 			_logger.LogInformation($"Processing Stripe Event Type: {stripeEvent.Type}");
 
-			if (stripeEvent.Type != EventTypes.CustomerDeleted)
+			if (stripeEvent.Type != EventTypes.CustomerSubscriptionDeleted)
 			{
-				throw new Exception($"Unhandled Stripe event type {stripeEvent.Type}");
+				_logger.LogWarning($"Ignoring unexpected Stripe event type {stripeEvent.Type}");
+				return Ok();
 			}
 
 			await HandleCustomerSubscriptionEnded(json);

--- a/src/DevBetterWeb.Web/Endpoints/StripeWebhookEndpoints/CustomerSubscriptionUpdatedWebHook.cs
+++ b/src/DevBetterWeb.Web/Endpoints/StripeWebhookEndpoints/CustomerSubscriptionUpdatedWebHook.cs
@@ -50,16 +50,23 @@ public class CustomerSubscriptionUpdatedWebHook : EndpointBaseAsync
 			json = await streamReader.ReadToEndAsync();
 		}
 
+		string? signatureHeader = Request.Headers["Stripe-Signature"];
+		if (string.IsNullOrEmpty(signatureHeader))
+		{
+			_logger.LogWarning("Missing Stripe-Signature header");
+			return BadRequest("Missing Stripe-Signature header");
+		}
+
 		try
 		{
-			var stripeEvent = EventUtility.ConstructEvent(json,
-				Request.Headers["Stripe-Signature"], _stripeWebHookSecretKey);
+			var stripeEvent = EventUtility.ConstructEvent(json, signatureHeader, _stripeWebHookSecretKey);
 
 			_logger.LogInformation($"Processing Stripe Event Type: {stripeEvent.Type}");
 
 			if (stripeEvent.Type != EventTypes.CustomerSubscriptionUpdated)
 			{
-				throw new Exception($"Unhandled Stripe event type {stripeEvent.Type}");
+				_logger.LogWarning($"Ignoring unexpected Stripe event type {stripeEvent.Type}");
+				return Ok();
 			}
 
 			var paymentHandlerEvent = _paymentHandlerEventService.FromJson(json);

--- a/src/DevBetterWeb.Web/Endpoints/StripeWebhookEndpoints/InvoicePaidWebHook.cs
+++ b/src/DevBetterWeb.Web/Endpoints/StripeWebhookEndpoints/InvoicePaidWebHook.cs
@@ -47,17 +47,24 @@ public class InvoicePaidWebHook : EndpointBaseAsync
 			json = await streamReader.ReadToEndAsync();
 		}
 
+		string? signatureHeader = Request.Headers["Stripe-Signature"];
+		if (string.IsNullOrEmpty(signatureHeader))
+		{
+			_logger.LogWarning("Missing Stripe-Signature header");
+			return BadRequest("Missing Stripe-Signature header");
+		}
+
 		try
 		{
-			var stripeEvent = EventUtility.ConstructEvent(json,
-				Request.Headers["Stripe-Signature"], _stripeWebHookSecretKey);
+			var stripeEvent = EventUtility.ConstructEvent(json, signatureHeader, _stripeWebHookSecretKey);
 
 			_logger.LogInformation($"Processing Stripe Event Type: {stripeEvent.Type}");
 
 			// Was InvoicePaymentSucceeded changed to InvoicePaid
 			if (stripeEvent.Type != EventTypes.InvoicePaid)
 			{
-				throw new Exception($"Unhandled Stripe event type {stripeEvent.Type}");
+				_logger.LogWarning($"Ignoring unexpected Stripe event type {stripeEvent.Type}");
+				return Ok();
 			}
 
 			await HandleInvoicePaymentSucceeded(json);

--- a/src/DevBetterWeb.Web/Endpoints/StripeWebhookEndpoints/PaymentIntentSucceededWebHook.cs
+++ b/src/DevBetterWeb.Web/Endpoints/StripeWebhookEndpoints/PaymentIntentSucceededWebHook.cs
@@ -41,16 +41,23 @@ public class PaymentIntentSucceededWebHook : EndpointBaseAsync
 			json = await streamReader.ReadToEndAsync();
 		}
 
+		string? signatureHeader = Request.Headers["Stripe-Signature"];
+		if (string.IsNullOrEmpty(signatureHeader))
+		{
+			_logger.LogWarning("Missing Stripe-Signature header");
+			return BadRequest("Missing Stripe-Signature header");
+		}
+
 		try
 		{
-			var stripeEvent = EventUtility.ConstructEvent(json,
-				Request.Headers["Stripe-Signature"], _stripeWebHookSecretKey);
+			var stripeEvent = EventUtility.ConstructEvent(json, signatureHeader, _stripeWebHookSecretKey);
 
 			_logger.LogInformation($"Processing Stripe Event Type: {stripeEvent.Type}");
 
 			if (stripeEvent.Type != EventTypes.PaymentIntentSucceeded)
 			{
-				throw new Exception($"Unhandled Stripe event type {stripeEvent.Type}");
+				_logger.LogWarning($"Ignoring unexpected Stripe event type {stripeEvent.Type}");
+				return Ok();
 			}
 
 			_ = (PaymentIntent)stripeEvent.Data.Object;

--- a/tests/DevBetterWeb.Tests/Endpoints/StripeWebhookEndpointTests/CustomerSubscriptionDeletedWebHookTests.cs
+++ b/tests/DevBetterWeb.Tests/Endpoints/StripeWebhookEndpointTests/CustomerSubscriptionDeletedWebHookTests.cs
@@ -1,0 +1,69 @@
+using System.Threading.Tasks;
+using DevBetterWeb.Core.Interfaces;
+using DevBetterWeb.Infrastructure.Services;
+using DevBetterWeb.Web.Endpoints;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Stripe;
+using Xunit;
+
+namespace DevBetterWeb.Tests.Endpoints.StripeWebhookEndpointTests;
+
+public class CustomerSubscriptionDeletedWebHookTests
+{
+  private readonly IWebhookHandlerService _webhookHandlerService = Substitute.For<IWebhookHandlerService>();
+
+  private CustomerSubscriptionDeletedWebHook CreateEndpoint()
+  {
+    var options = Options.Create(new StripeOptions
+    {
+      StripeCustomerSubscriptionDeletedWebHookSecretKey = StripeWebhookTestHelper.TestSecret
+    });
+
+    return new CustomerSubscriptionDeletedWebHook(
+      Substitute.For<IAppLogger<CustomerSubscriptionDeletedWebHook>>(),
+      options,
+      _webhookHandlerService);
+  }
+
+  [Fact]
+  public async Task ReturnsBadRequestGivenMissingSignatureHeader()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.CustomerSubscriptionDeleted);
+    StripeWebhookTestHelper.SetRequest(endpoint, json, signatureHeader: null);
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<BadRequestObjectResult>(result);
+  }
+
+  [Fact]
+  public async Task ReturnsOkWithoutProcessingGivenUnexpectedEventType()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.CustomerDeleted,
+      dataObjectJson: "{\"object\":\"customer\",\"id\":\"cus_test\"}");
+    StripeWebhookTestHelper.SetRequest(endpoint, json, StripeWebhookTestHelper.SignPayload(json));
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<OkResult>(result);
+    await _webhookHandlerService.DidNotReceiveWithAnyArgs().HandleCustomerSubscriptionEndedAsync(default!);
+  }
+
+  [Fact]
+  public async Task HandlesSubscriptionEndedGivenCustomerSubscriptionDeletedEvent()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.CustomerSubscriptionDeleted,
+      dataObjectJson: "{\"object\":\"subscription\",\"id\":\"sub_test\"}");
+    StripeWebhookTestHelper.SetRequest(endpoint, json, StripeWebhookTestHelper.SignPayload(json));
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<OkResult>(result);
+    await _webhookHandlerService.Received(1).HandleCustomerSubscriptionEndedAsync(json);
+  }
+}

--- a/tests/DevBetterWeb.Tests/Endpoints/StripeWebhookEndpointTests/CustomerSubscriptionUpdatedWebHookTests.cs
+++ b/tests/DevBetterWeb.Tests/Endpoints/StripeWebhookEndpointTests/CustomerSubscriptionUpdatedWebHookTests.cs
@@ -1,0 +1,59 @@
+using System.Threading.Tasks;
+using DevBetterWeb.Core.Interfaces;
+using DevBetterWeb.Infrastructure.Interfaces;
+using DevBetterWeb.Infrastructure.Services;
+using DevBetterWeb.Web.Endpoints;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Stripe;
+using Xunit;
+
+namespace DevBetterWeb.Tests.Endpoints.StripeWebhookEndpointTests;
+
+public class CustomerSubscriptionUpdatedWebHookTests
+{
+  private readonly IPaymentHandlerEventService _paymentHandlerEventService = Substitute.For<IPaymentHandlerEventService>();
+  private readonly IPaymentHandlerSubscription _paymentHandlerSubscription = Substitute.For<IPaymentHandlerSubscription>();
+  private readonly IWebhookHandlerService _webhookHandlerService = Substitute.For<IWebhookHandlerService>();
+
+  private CustomerSubscriptionUpdatedWebHook CreateEndpoint()
+  {
+    var options = Options.Create(new StripeOptions
+    {
+      StripeCustomerSubscriptionUpdatedWebHookSecretKey = StripeWebhookTestHelper.TestSecret
+    });
+
+    return new CustomerSubscriptionUpdatedWebHook(
+      Substitute.For<IAppLogger<CustomerSubscriptionDeletedWebHook>>(),
+      options,
+      _paymentHandlerEventService,
+      _paymentHandlerSubscription,
+      _webhookHandlerService);
+  }
+
+  [Fact]
+  public async Task ReturnsBadRequestGivenMissingSignatureHeader()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.CustomerSubscriptionUpdated);
+    StripeWebhookTestHelper.SetRequest(endpoint, json, signatureHeader: null);
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<BadRequestObjectResult>(result);
+  }
+
+  [Fact]
+  public async Task ReturnsOkWithoutProcessingGivenUnexpectedEventType()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.CustomerSubscriptionCreated);
+    StripeWebhookTestHelper.SetRequest(endpoint, json, StripeWebhookTestHelper.SignPayload(json));
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<OkResult>(result);
+    _paymentHandlerEventService.DidNotReceiveWithAnyArgs().FromJson(default!);
+  }
+}

--- a/tests/DevBetterWeb.Tests/Endpoints/StripeWebhookEndpointTests/InvoicePaidWebHookTests.cs
+++ b/tests/DevBetterWeb.Tests/Endpoints/StripeWebhookEndpointTests/InvoicePaidWebHookTests.cs
@@ -1,0 +1,82 @@
+using System.Threading.Tasks;
+using DevBetterWeb.Core.Interfaces;
+using DevBetterWeb.Infrastructure.Services;
+using DevBetterWeb.Web.Endpoints;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Stripe;
+using Xunit;
+
+namespace DevBetterWeb.Tests.Endpoints.StripeWebhookEndpointTests;
+
+public class InvoicePaidWebHookTests
+{
+  private readonly IWebhookHandlerService _webhookHandlerService = Substitute.For<IWebhookHandlerService>();
+  private readonly IPaymentHandlerInvoice _paymentHandlerInvoice = Substitute.For<IPaymentHandlerInvoice>();
+
+  private InvoicePaidWebHook CreateEndpoint()
+  {
+    var options = Options.Create(new StripeOptions
+    {
+      StripeInvoicePaidWebHookSecretKey = StripeWebhookTestHelper.TestSecret
+    });
+
+    return new InvoicePaidWebHook(
+      Substitute.For<IAppLogger<InvoicePaidWebHook>>(),
+      options,
+      _webhookHandlerService,
+      _paymentHandlerInvoice);
+  }
+
+  [Fact]
+  public async Task ReturnsBadRequestGivenMissingSignatureHeader()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.InvoicePaid);
+    StripeWebhookTestHelper.SetRequest(endpoint, json, signatureHeader: null);
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<BadRequestObjectResult>(result);
+  }
+
+  [Fact]
+  public async Task ReturnsBadRequestGivenInvalidSignature()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.InvoicePaid);
+    StripeWebhookTestHelper.SetRequest(endpoint, json, "t=123,v1=invalid");
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<BadRequestObjectResult>(result);
+  }
+
+  [Fact]
+  public async Task ReturnsOkWithoutProcessingGivenUnexpectedEventType()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.InvoiceCreated);
+    StripeWebhookTestHelper.SetRequest(endpoint, json, StripeWebhookTestHelper.SignPayload(json));
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<OkResult>(result);
+    await _webhookHandlerService.DidNotReceiveWithAnyArgs().HandleNewCustomerSubscriptionAsync(default!);
+  }
+
+  [Fact]
+  public async Task HandlesNewSubscriptionGivenInvoicePaidForSubscriptionCreation()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.InvoicePaid);
+    _paymentHandlerInvoice.GetBillingReason(json).Returns("subscription_create");
+    StripeWebhookTestHelper.SetRequest(endpoint, json, StripeWebhookTestHelper.SignPayload(json));
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<OkResult>(result);
+    await _webhookHandlerService.Received(1).HandleNewCustomerSubscriptionAsync(json);
+  }
+}

--- a/tests/DevBetterWeb.Tests/Endpoints/StripeWebhookEndpointTests/PaymentIntentSucceededWebHookTests.cs
+++ b/tests/DevBetterWeb.Tests/Endpoints/StripeWebhookEndpointTests/PaymentIntentSucceededWebHookTests.cs
@@ -1,0 +1,65 @@
+using System.Threading.Tasks;
+using DevBetterWeb.Core.Interfaces;
+using DevBetterWeb.Infrastructure.Services;
+using DevBetterWeb.Web.Endpoints;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Stripe;
+using Xunit;
+
+namespace DevBetterWeb.Tests.Endpoints.StripeWebhookEndpointTests;
+
+public class PaymentIntentSucceededWebHookTests
+{
+  private static PaymentIntentSucceededWebHook CreateEndpoint()
+  {
+    var options = Options.Create(new StripeOptions
+    {
+      StripePaymentIntentSucceededWebHookSecretKey = StripeWebhookTestHelper.TestSecret
+    });
+
+    return new PaymentIntentSucceededWebHook(
+      Substitute.For<IAppLogger<InvoicePaidWebHook>>(),
+      options);
+  }
+
+  [Fact]
+  public async Task ReturnsBadRequestGivenMissingSignatureHeader()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.PaymentIntentSucceeded,
+      dataObjectJson: "{\"object\":\"payment_intent\",\"id\":\"pi_test\"}");
+    StripeWebhookTestHelper.SetRequest(endpoint, json, signatureHeader: null);
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<BadRequestObjectResult>(result);
+  }
+
+  [Fact]
+  public async Task ReturnsOkGivenUnexpectedEventType()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.PaymentIntentCreated,
+      dataObjectJson: "{\"object\":\"payment_intent\",\"id\":\"pi_test\"}");
+    StripeWebhookTestHelper.SetRequest(endpoint, json, StripeWebhookTestHelper.SignPayload(json));
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<OkResult>(result);
+  }
+
+  [Fact]
+  public async Task ReturnsOkGivenPaymentIntentSucceededEvent()
+  {
+    var endpoint = CreateEndpoint();
+    var json = StripeWebhookTestHelper.BuildEventJson(EventTypes.PaymentIntentSucceeded,
+      dataObjectJson: "{\"object\":\"payment_intent\",\"id\":\"pi_test\"}");
+    StripeWebhookTestHelper.SetRequest(endpoint, json, StripeWebhookTestHelper.SignPayload(json));
+
+    var result = await endpoint.HandleAsync();
+
+    Assert.IsType<OkResult>(result);
+  }
+}

--- a/tests/DevBetterWeb.Tests/Endpoints/StripeWebhookEndpointTests/StripeWebhookTestHelper.cs
+++ b/tests/DevBetterWeb.Tests/Endpoints/StripeWebhookEndpointTests/StripeWebhookTestHelper.cs
@@ -1,0 +1,45 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace DevBetterWeb.Tests.Endpoints.StripeWebhookEndpointTests;
+
+public static class StripeWebhookTestHelper
+{
+  public const string TestSecret = "whsec_test_secret";
+
+  // Matches the API version pinned by the referenced Stripe.net SDK; events with a
+  // different major version are rejected by EventUtility.ConstructEvent.
+  public const string CompatibleApiVersion = "2026-07-29.dahlia";
+
+  public static string BuildEventJson(string eventType, string apiVersion = CompatibleApiVersion,
+    string dataObjectJson = "{\"object\":\"invoice\",\"billing_reason\":\"manual\"}")
+  {
+    return "{\"id\":\"evt_test\",\"object\":\"event\",\"api_version\":\"" + apiVersion +
+      "\",\"type\":\"" + eventType + "\",\"data\":{\"object\":" + dataObjectJson + "}}";
+  }
+
+  public static string SignPayload(string payload, string secret = TestSecret)
+  {
+    var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+    using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+    var hash = hmac.ComputeHash(Encoding.UTF8.GetBytes($"{timestamp}.{payload}"));
+    var signature = Convert.ToHexString(hash).ToLowerInvariant();
+    return $"t={timestamp},v1={signature}";
+  }
+
+  public static void SetRequest(ControllerBase endpoint, string body, string? signatureHeader)
+  {
+    var httpContext = new DefaultHttpContext();
+    httpContext.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(body));
+    if (signatureHeader is not null)
+    {
+      httpContext.Request.Headers["Stripe-Signature"] = signatureHeader;
+    }
+
+    endpoint.ControllerContext = new ControllerContext { HttpContext = httpContext };
+  }
+}


### PR DESCRIPTION
## Why

Stripe emailed that it cannot reach `https://devbetter.com/stripe-invoice-paid-web-hook/`. The endpoint is reachable — investigation showed Stripe deliveries are being **rejected with 400s** and some paths return **500s**.

## Root cause (requires a manual dashboard fix — see below)

Stripe.net 52.x (deployed Aug 7 via `9f8cdeda`; the check has existed since the 40.16 → 51.1 jump in May, first actually deployed with the .NET 10 upgrade in #1407) only accepts webhook events whose `api_version` is in the **`2026-07-29.dahlia`** family. Our dashboard webhook endpoints are pinned to an older API version, so `EventUtility.ConstructEvent` throws on **every** delivery and the endpoints answer 400. Verified by decompiling both SDK versions and reproducing with correctly-signed payloads:

```
api_version 2022-11-15:        StripeException -> "...expects API version 2026-07-29.dahlia"
api_version 2026-07-29.dahlia: OK -> invoice.paid
```

The strict version check is intentionally **kept**: payload parsing was already migrated to dahlia shapes (`invoice.parent.subscription_details`) in #1407, so silencing the check would deserialize old-shape payloads into empty subscription IDs.

## Code fixes in this PR

All four Stripe webhook endpoints (`invoice-paid`, `customer-subscription-updated`, `customer-subscription-deleted`, `payment-intent-succeeded`):

1. **Missing `Stripe-Signature` header → 400** instead of an uncaught `NullReferenceException` (500).
2. **Unexpected event types → logged warning + 200** instead of a bare `throw new Exception` (500). Stripe recommends acknowledging events you don't process; retrying can't help.
3. **Bug fix:** `CustomerSubscriptionDeletedWebHook` checked `EventTypes.CustomerDeleted` (`customer.deleted`) instead of `CustomerSubscriptionDeleted` (`customer.subscription.deleted`) — it rejected every event it was subscribed to (long-standing, predates the SDK upgrade).

Adds 12 unit tests with real HMAC-signed payloads (all watched failing first, TDD).

## ⚠️ Manual steps (required to actually restore webhooks)

1. **Stripe Dashboard → Workbench → Webhooks**: open each webhook endpoint (invoice-paid, subscription-updated, subscription-deleted, payment-intent-succeeded) and check the recent delivery attempts. The 400 response bodies should read *"Received event with API version XXXX, but Stripe.net 52.2.0 expects API version 2026-07-29.dahlia"* — confirming the diagnosis.
2. On each endpoint, **change the API version to `2026-07-29.dahlia`** (endpoint settings → API version). Do this for all four.
3. If Stripe **disabled** any endpoint after repeated failures, re-enable it.
4. Merge + deploy this PR.
5. In the dashboard, **resend a recent failed `invoice.paid` event** and confirm a 200 response. Recent real invoices that failed during the outage may need to be replayed the same way so renewals/new-member processing catches up.
6. Codex review was run locally (`codex exec`); findings addressed except one deferred: signature-failure logging passes raw webhook JSON to the logger (pre-existing pattern, message has no placeholder so payload isn't actually rendered) — candidate for a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)